### PR TITLE
Fixup GitHub Actions build YAML and format YAML in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,8 +35,6 @@ jobs:
   text:
     name: Lint and format text
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -45,4 +43,7 @@ jobs:
         run: npx prettier --check '**/*'
 
       - name: Format markdown with prettier
-        run: npx prettier --prose-wrap always --check '**/*.md' '*.md'
+        run: npx prettier --prose-wrap always --check '**/*.md'
+
+      - name: Format YAML with prettier
+        run: npx prettier --prose-wrap always --check '**/*.{yaml,yml}'

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
     "dev": "npx webpack-dev-server",
     "dev:open": "npx webpack-dev-server --open",
     "fmt": "npx prettier --write '**/*'",
-    "fmt:md": "npx prettier --prose-wrap always --write '**/*.md' '*.md'"
+    "fmt:all": "npm run fmt && npm run fmt:md && npm run fmt:yaml",
+    "fmt:md": "npx prettier --prose-wrap always --write '**/*.md'",
+    "fmt:yaml": "npx prettier --prose-wrap always --write '**/*.{yaml,yml}'"
   }
 }


### PR DESCRIPTION
strategy.fail-fast is not valid without a matrix
fixup prettier globs for prettier 2.0
check YAML formatting in CI
add more formatting package scripts: fmt:all and fmt:yaml