### PR TITLE
Bump jquery to 3.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4150,9 +4150,9 @@
       }
     },
     "jquery": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
+      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
     },
     "js-yaml": {
       "version": "3.13.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "repository": "github:artichoke/www.artichokeruby.org",
   "dependencies": {
     "bootstrap": "^4.4.1",
-    "jquery": "~3.4.1",
+    "jquery": "^3.5.1",
     "popper.js": "^1.16.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Fix CVE-2020-11023 and pull in the fix for the data regression in 3.5.0.