### PR TITLE
Bundle highlight.js with webpack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3427,6 +3427,11 @@
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
       "dev": true
     },
+    "highlight.js": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.0.2.tgz",
+      "integrity": "sha512-2gMT2MHU6/2OjAlnaOE2LFdr9dwviDN3Q2lSw7Ois3/5uTtahbgYTkr4EPoY828ps+2eQWiixPTF8+phU6Ofkg=="
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "repository": "github:artichoke/www.artichokeruby.org",
   "dependencies": {
     "bootstrap": "^4.4.1",
+    "highlight.js": "^10.0.2",
     "jquery": "^3.5.1",
     "popper.js": "^1.16.1"
   },

--- a/src/index.html
+++ b/src/index.html
@@ -23,6 +23,7 @@
       property="og:image"
       content="https://www.artichokeruby.org/artichoke-logo.png"
     />
+    <link rel="canonical" href="https://www.artichokeruby.org/" />
 
     <%= require('html-loader!./partials/favicons.html') %> <%=
     require('html-loader!./partials/google-analytics.html') %>

--- a/src/install.html
+++ b/src/install.html
@@ -16,19 +16,14 @@
     <meta property="og:url" content="https://www.artichokeruby.org/install/" />
     <meta
       property="og:description"
-      content="Artichoke Ruby is a Ruby made with Rust."
+      content="Install Artichoke Ruby – a Ruby made with Rust."
     />
     <meta property="og:type" content="website" />
     <meta
       property="og:image"
       content="https://www.artichokeruby.org/artichoke-logo.png"
     />
-
-    <!-- highight.js -->
-    <link
-      rel="stylesheet"
-      href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/default.min.css"
-    />
+    <link rel="canonical" href="https://www.artichokeruby.org/install/" />
 
     <%= require('html-loader!./partials/favicons.html') %> <%=
     require('html-loader!./partials/google-analytics.html') %>
@@ -138,9 +133,5 @@ artichoke 0.1.0 (2020-04-01 revision 2921) [x86_64-darwin]</code></pre>
     </div>
 
     <%= require('html-loader!./partials/footer.html') %>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/highlight.min.js"></script>
-    <script>
-      hljs.initHighlightingOnLoad();
-    </script>
   </body>
 </html>

--- a/src/install.js
+++ b/src/install.js
@@ -1,0 +1,7 @@
+import "bootstrap";
+import "bootstrap/dist/css/bootstrap.min.css";
+
+import hljs from "highlight.js";
+import "highlight.js/styles/default.css";
+
+hljs.initHighlightingOnLoad();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,12 +7,13 @@ const TerserPlugin = require("terser-webpack-plugin");
 
 const plugins = [
   new MiniCssExtractPlugin({
-    filename: "[hash].css",
+    filename: "[name].[hash].css",
     chunkFilename: "[id].css",
   }),
   new HtmlWebPackPlugin({
     template: "index.html",
     filename: "index.html",
+    chunks: ["index"],
     minify: {
       collapseWhitespace: true,
       minifyCSS: true,
@@ -24,6 +25,7 @@ const plugins = [
   new HtmlWebPackPlugin({
     template: "install.html",
     filename: "install/index.html",
+    chunks: ["install"],
     minify: {
       collapseWhitespace: true,
       minifyCSS: true,
@@ -44,7 +46,10 @@ module.exports = {
       assets: path.resolve(__dirname, "assets"),
     },
   },
-  entry: path.resolve(__dirname, "src/index.js"),
+  entry: {
+    index: path.resolve(__dirname, "src/index.js"),
+    install: path.resolve(__dirname, "src/install.js"),
+  },
   output: {
     path: path.resolve(__dirname, "dist"),
     publicPath: "/",


### PR DESCRIPTION
- Update to highlight.js 10.x
- Add rel=canonical link tags to handle GitHub Pages index.html dirindex.
- Update meta og:description tag for install page.
- Split entrypoints for install and index page.