### PR TITLE
Highlight code snippets at build time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3866,9 +3866,9 @@
           }
         },
         "domutils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.0.0.tgz",
-          "integrity": "sha512-n5SelJ1axbO636c2yUtOGia/IcJtVtlhQbFiVDBZHKV5ReJO1ViX7sFEemtuyoAnBxk5meNSYgA8V4s0271efg==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.1.0.tgz",
+          "integrity": "sha512-CD9M0Dm1iaHfQ1R/TI+z3/JWp/pgub0j4jIQKH89ARR4ATAV2nbaOQS5XxU9maJP5jHaPdDDQSEHuE2UmpUTKg==",
           "dev": true,
           "requires": {
             "dom-serializer": "^0.2.1",
@@ -3909,9 +3909,9 @@
           }
         },
         "schema-utils": {
-          "version": "2.6.5",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.5.tgz",
-          "integrity": "sha512-5KXuwKziQrTVHh8j/Uxz+QUbxkaLW9X/86NBlx/gnKgtsZA2GIVMUn17qWhRFwF8jdYb3Dig5hRO/W5mZqy6SQ==",
+          "version": "2.6.6",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.6.tgz",
+          "integrity": "sha512-wHutF/WPSbIi9x6ctjGGk2Hvl0VOz5l3EKEuKbjPlB30mKZUzb9A5k9yEXRX3pwyqVLPvpfZZEllaFq/M718hA==",
           "dev": true,
           "requires": {
             "ajv": "^6.12.0",
@@ -4810,6 +4810,22 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "markdown-loader": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-loader/-/markdown-loader-5.1.0.tgz",
+      "integrity": "sha512-xtQNozLEL+55ZSPTNwro8epZqf1h7HjAZd/69zNe8lbckDiGVHeLQm849bXzocln2pwRK2A/GrW/7MAmwjcFog==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.2.3",
+        "marked": "^0.7.0"
+      }
+    },
+    "marked": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
+      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
+      "dev": true
     },
     "md5.js": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "file-loader": "^6.0.0",
     "html-loader": "^1.1.0",
     "html-webpack-plugin": "^4.3.0",
+    "markdown-loader": "^5.1.0",
     "mini-css-extract-plugin": "^0.9.0",
     "node-sass": "^4.14.1",
     "optimize-css-assets-webpack-plugin": "^5.0.3",

--- a/src/cargo-install.md
+++ b/src/cargo-install.md
@@ -1,0 +1,3 @@
+```bash
+cargo install --git https://github.com/artichoke/artichoke --locked artichoke
+```

--- a/src/cli-artichoke.md
+++ b/src/cli-artichoke.md
@@ -1,0 +1,4 @@
+```shell
+$ artichoke -e "puts RUBY_DESCRIPTION"
+artichoke 0.1.0 (2020-04-01 revision 2921) [x86_64-darwin]
+```

--- a/src/docker-run.md
+++ b/src/docker-run.md
@@ -1,0 +1,3 @@
+```bash
+docker run -it docker.io/artichokeruby/artichoke airb
+```

--- a/src/install.html
+++ b/src/install.html
@@ -79,9 +79,7 @@
         <div id="docker" class="col-12 my-1">
           <div class="p-2 p-md-5 bg-dark text-light">
             <h4>Using Docker</h4>
-            <pre
-              class="hljs"
-            ><code class="bash">docker run -it docker.io/artichokeruby/artichoke airb</code></pre>
+            <%= require('./docker-run.md') %>
             <p>
               Docker tags are updated nightly. Images are built on Ubuntu,
               Debian Slim, and Alpine.
@@ -91,9 +89,7 @@
         <div id="cargo" class="col-12 my-1">
           <div class="p-2 p-md-5">
             <h4>Using Cargo</h4>
-            <pre
-              class="hljs"
-            ><code class="bash">cargo install --git https://github.com/artichoke/artichoke --locked artichoke</code></pre>
+            <%= require('./cargo-install.md') %>
             <p>
               <a
                 href="https://github.com/artichoke/artichoke/blob/master/BUILD.md"
@@ -111,10 +107,7 @@
               Build applications with <code>artichoke</code>.
             </p>
             <div>
-              <pre
-                class="hljs console"
-              ><code>$ artichoke -e "puts RUBY_DESCRIPTION"
-artichoke 0.1.0 (2020-04-01 revision 2921) [x86_64-darwin]</code></pre>
+              <%= require('./cli-artichoke.md') %>
             </div>
           </div>
         </div>
@@ -122,10 +115,8 @@ artichoke 0.1.0 (2020-04-01 revision 2921) [x86_64-darwin]</code></pre>
           <div class="bg-light p-2 p-md-5 h-100">
             <h2 class="text-center">REPL</h2>
             <p class="lead text-center">Explore with <code>airb</code>.</p>
-            <div class="mt-1 text-left">
-              <pre class="hljs console"><code>$ airb
-&gt;&gt;&gt; "Hello world!"
-=&gt; "Hello world!"</code></pre>
+            <div>
+              <%= require('./repl-airb.md') %>
             </div>
           </div>
         </div>

--- a/src/install.js
+++ b/src/install.js
@@ -1,17 +1,4 @@
 import "bootstrap";
 import "./bootstrap-slim.scss";
 
-import hljs from "highlight.js/lib/core";
 import "highlight.js/styles/default.css";
-import bash from "highlight.js/lib/languages/bash";
-import shell from "highlight.js/lib/languages/shell";
-
-hljs.registerLanguage("bash", bash);
-hljs.registerLanguage("console", shell);
-hljs.registerLanguage("shell", shell);
-
-document.addEventListener("DOMContentLoaded", () => {
-  document.querySelectorAll("pre code").forEach((block) => {
-    hljs.highlightBlock(block);
-  });
-});

--- a/src/repl-airb.md
+++ b/src/repl-airb.md
@@ -1,0 +1,5 @@
+```shell
+$ airb
+>>> "Hello world!"
+=> "Hello world!"
+```

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,8 @@ const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
 const TerserPlugin = require("terser-webpack-plugin");
 
+const hljs = require("highlight.js");
+
 const plugins = [
   new MiniCssExtractPlugin({
     filename: "[contenthash].css",
@@ -83,6 +85,32 @@ module.exports = {
         test: /\.svg$/,
         exclude: new RegExp(path.resolve(__dirname, "assets")),
         use: ["file-loader", "svgo-loader"],
+      },
+      {
+        test: /\.md$/,
+        use: [
+          "html-loader",
+          {
+            loader: "markdown-loader",
+            options: {
+              langPrefix: "hljs language-",
+              highlight: (code, lang) => {
+                switch (lang) {
+                  case null:
+                  case "text":
+                  case "literal":
+                  case "nohighlight": {
+                    return `<pre class="hljs">${code}</pre>`;
+                  }
+                  default: {
+                    const html = hljs.highlight(lang, code).value;
+                    return `<span class="hljs">${html}</span>`;
+                  }
+                }
+              },
+            },
+          },
+        ],
       },
     ],
   },


### PR DESCRIPTION
Remove the runtime dependency on `highlight.js`.

This PR factors out the code snippets in `install.html` to markdown sources that annotate the fenced code blocks with the hljs language. `*.md` files are loaded by webpack via `markdown-loader` and `html-loader`.

I've plugged in a custom highlighter to `markdown-loader` that uses `highlight.js`.

To get the spacing right required some hackery with the `langPrefix` option to add an `hljs` class on a block element.

`highlight.js` is removed from the `install.js` runtime bundle.