### PR TITLE
Force the twitter timeline to be responsive

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,10 +6,12 @@ dist/
 node_modules/
 target/
 
+!*.css
 !*.html
 !*.js
 !*.json
 !*.md
+!*.scss
 !*.yaml
 !*.yml
 

--- a/src/index.html
+++ b/src/index.html
@@ -127,7 +127,6 @@
           <div class="bg-dark h-100 p-1 p-md-3 text-center text-light">
             <a
               class="twitter-timeline"
-              data-height="500px"
               data-theme="light"
               href="https://twitter.com/artichokeruby?ref_src=twsrc%5Etfw"
             >

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 import "bootstrap";
 import "./bootstrap-slim.scss";
 
+import "./twitter-feed.scss";
+
 // Favicons
 import "assets/favicons/android-chrome-192x192.png";
 import "assets/favicons/android-chrome-512x512.png";

--- a/src/rbenv-install.md
+++ b/src/rbenv-install.md
@@ -1,5 +1,8 @@
-Binaries are also distributed through ruby-build. To install with rbenv:
+Binaries are also distributed through [ruby-build]. To install with [rbenv]:
 
 ```bash
 rbenv install artichoke-dev
 ```
+
+[ruby-build]: https://github.com/rbenv/ruby-build
+[rbenv]: https://github.com/rbenv/rbenv

--- a/src/twitter-feed.scss
+++ b/src/twitter-feed.scss
@@ -1,0 +1,4 @@
+#twitter-widget-0 {
+  width: 100% !important;
+  height: 100% !important;
+}


### PR DESCRIPTION
This forces the twitter feed to fill the cell vertically.

Enable prettier formatting for CSS and SCSS sources.

Also linkifies `rbenv` and `ruby-build` on install page.