### PR TITLE
Use bootstrap-icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -699,6 +699,11 @@
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.0.0-alpha1.tgz",
       "integrity": "sha512-iwKneP2pLXl8lN0YpnOuOARiNPTzmh/4cw+Un86u4OqrMLuQpyMC7nO07hvivvcg0B/ektJPjuPnS1s+YmRK9A=="
     },
+    "bootstrap-icons": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.0.0.tgz",
+      "integrity": "sha512-PaQm3VtSqbUnWuyqGmFJG5iF9UMieDuk8raPOmKOtKeyWyiVshgLoKa+9EWGolGU/nvyBLEBWhZoQqhu9ccNBg=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "repository": "github:artichoke/www.artichokeruby.org",
   "dependencies": {
     "bootstrap": "^5.0.0-alpha1",
+    "bootstrap-icons": "^1.0.0",
     "highlight.js": "^10.1.2",
     "popper.js": "^1.16.1"
   },

--- a/src/index.html
+++ b/src/index.html
@@ -120,23 +120,21 @@
       <div class="row mb-5 pb-md-4 align-items-center">
         <div class="col-md-5">
           <div
-            class="masthead-followup-icon d-inline-block mb-2 text-white bg-success"
+            class="masthead-followup-icon d-inline-block mb-2 text-white bg-artichoke"
           >
             <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 576 512"
               width="32"
+              height="32"
+              viewBox="0 0 16 16"
+              class="bi bi-gem"
+              fill="currentColor"
+              xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                fill="white"
-                d="M464 0H112c-4 0-7.8 2-10 5.4L2 152.6c-2.9 4.4-2.6 10.2.7 14.2l276 340.8c4.8 5.9 13.8 5.9 18.6 0l276-340.8c3.3-4.1 3.6-9.8.7-14.2L474.1 5.4C471.8 2 468.1 0 464 0zm-19.3 48l63.3 96h-68.4l-51.7-96h56.8zm-202.1 0h90.7l51.7 96H191l51.6-96zm-111.3 0h56.8l-51.7 96H68l63.3-96zm-43 144h51.4L208 352 88.3 192zm102.9 0h193.6L288 435.3 191.2 192zM368 352l68.2-160h51.4L368 352z"
+                fill-rule="evenodd"
+                d="M3.1.7a.5.5 0 0 1 .4-.2h9a.5.5 0 0 1 .4.2l2.976 3.974c.149.185.156.45.01.644L8.4 15.3a.5.5 0 0 1-.8 0L.1 5.3a.5.5 0 0 1 0-.6l3-4zm11.386 3.785l-1.806-2.41-.776 2.413 2.582-.003zm-3.633.004l.961-2.989H4.186l.963 2.995 5.704-.006zM5.47 5.495l5.062-.005L8 13.366 5.47 5.495zm-1.371-.999l-.78-2.422-1.818 2.425 2.598-.003zM1.499 5.5l2.92-.003 2.193 6.82L1.5 5.5zm7.889 6.817l2.194-6.828 2.929-.003-5.123 6.831z"
               />
             </svg>
-            <!--
-              Font Awesome Free 5.2.0 by @fontawesome - https://fontawesome.com
-              License - https://fontawesome.com/license (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
-              Source: https://upload.wikimedia.org/wikipedia/commons/8/8e/Font_Awesome_5_regular_gem.svg
-            -->
           </div>
           <h2 class="display-5 font-weight-normal">Installation</h2>
           <p class="lead font-weight-normal">

--- a/src/index.scss
+++ b/src/index.scss
@@ -43,3 +43,9 @@
   border-radius: 0.75rem;
   box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.1);
 }
+
+.bg-artichoke {
+  color: #fff;
+  background-color: #99ba37;
+  border-color: #99ba37;
+}

--- a/src/install.html
+++ b/src/install.html
@@ -115,44 +115,21 @@
       <div id="nightly" class="row mb-5 pb-md-4 align-items-center">
         <div class="col-md-5">
           <div
-            class="masthead-followup-icon d-inline-block mb-2 text-white bg-success"
+            class="masthead-followup-icon d-inline-block mb-2 text-white bg-nightly"
           >
             <svg
-              version="1.1"
-              id="Layer_1"
-              xmlns="http://www.w3.org/2000/svg"
-              xmlns:xlink="http://www.w3.org/1999/xlink"
-              x="0px"
-              y="0px"
-              viewBox="0 0 64 64"
-              enable-background="new 0 0 64 64"
-              xml:space="preserve"
               width="32"
+              height="32"
+              viewBox="0 0 16 16"
+              class="bi bi-moon"
+              fill="currentColor"
+              xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                stroke="white"
-                fill="white"
-                id="Moon"
-                d="M63.4374046,38.4606323c-0.4258003-0.2060013-0.9384995-0.0848999-1.2276001,0.2910995
-	c-1.2803001,1.6650009-2.9452972,3.2001991-4.9501991,4.5625c-11.6180992,7.8808022-27.544899,4.9248009-35.4971008-6.5956993
-	c-7.8154011-11.3204002-4.9902-26.9736996,6.2968998-34.8936005c0.3799-0.2666,0.5263996-0.7588,0.3544998-1.1895001
-	c-0.1728001-0.4316-0.625-0.6835-1.0771008-0.6181c-4.6474991,0.6953-9.2070999,2.4902-13.1875,5.1893997
-	C6.9706059,10.0759325,2.1415057,17.427433,0.5526057,25.9079323c-1.582,8.4414024,0.2402,16.9932022,5.1308002,24.0791016
-	c6.2872,9.1054993,16.4864006,14.0058975,26.8554993,14.0058975c6.3173981,0,12.6982994-1.819397,18.2939987-5.6161995
-	c6.5800018-4.461998,11.2461014-11.1298981,13.1406021-18.7753983
-	C64.0877075,39.142334,63.8631058,38.6657333,63.4374046,38.4606323z M49.7098045,56.7224312
-	c-13.8710976,9.410099-32.8847961,5.8828011-42.3798981-7.872097c-4.5858998-6.642601-6.2948999-14.660202-4.8114996-22.5742016
-	C4.0086055,18.3239326,8.5379057,11.4294329,15.2723055,6.861033c2.5801001-1.75,5.4189997-3.0937002,8.3643007-3.9726
-	c-9.3916006,9.0702991-11.1416006,23.9258003-3.5205002,34.9668007
-	c8.5741997,12.4188995,25.7422009,15.6094017,38.2666016,7.1133003c0.8260994-0.5606003,1.5996017-1.149498,2.3182983-1.764698
-	C58.4803047,48.6472321,54.6766052,53.3542328,49.7098045,56.7224312z"
+                fill-rule="evenodd"
+                d="M14.53 10.53a7 7 0 0 1-9.058-9.058A7.003 7.003 0 0 0 8 15a7.002 7.002 0 0 0 6.53-4.47z"
               />
             </svg>
-            <!--
-              COLLECTION: Multimedia Controls
-              License - CC0 License
-              Source: https://www.svgrepo.com/svg/83109/moon
-            -->
           </div>
           <h2 class="display-5 font-weight-normal">
             Pre-compiled nightly builds
@@ -216,7 +193,7 @@
       <div id="cargo" class="row mb-5 pb-md-4 align-items-center">
         <div class="col-md-5">
           <div
-            class="masthead-followup-icon d-inline-block mb-2 text-white bg-dark"
+            class="masthead-followup-icon d-inline-block mb-2 text-white bg-cargo"
           >
             <img
               alt="Rust Cargo"

--- a/src/install.scss
+++ b/src/install.scss
@@ -43,3 +43,15 @@
   border-radius: 0.75rem;
   box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.1);
 }
+
+.bg-nightly {
+  color: white;
+  background-color: #191970;
+  border-color: #191970;
+}
+
+.bg-cargo {
+  color: white;
+  background-color: #3b6837;
+  border-color: #3b6837;
+}


### PR DESCRIPTION
Replace bespoke icons with varying licenses.

This commit updates the background color of the gem, nightly, and cargo
section icons.