### PR TITLE
Rename 'Deploy Docs' CI step to 'Deploy'

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Webpack build
         run: npx webpack --mode production
 
-      - name: Deploy Docs
+      - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         if: github.ref == 'refs/heads/trunk'
         with:


### PR DESCRIPTION
This is a copypasta from a Rust repo long ago.