### PR TITLE
Clarify alt text for logo images

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,9 @@
     }
   },
   "scripts": {
-    "dev": "npx webpack-dev-server",
-    "dev:open": "npx webpack-dev-server --open",
+    "build": "webpack --mode production",
+    "dev": "webpack-dev-server",
+    "dev:open": "webpack-dev-server --open",
     "fmt": "npx prettier --write '**/*'",
     "lint": "npx eslint --fix ."
   }

--- a/src/index.html
+++ b/src/index.html
@@ -162,7 +162,6 @@
           >
             <img
               alt="Twitter logo"
-              title="Twitter"
               width="32"
               height="32"
               src="<%= require('./partials/social/twitter-logo.svg').default %>"

--- a/src/install.html
+++ b/src/install.html
@@ -196,7 +196,7 @@
             class="masthead-followup-icon d-inline-block mb-2 text-white bg-cargo"
           >
             <img
-              alt="Rust Cargo"
+              alt="Rust Cargo logo"
               width="32"
               src="<%= require('./logos/cargo.png').default %>"
             />

--- a/src/partials/footer.html
+++ b/src/partials/footer.html
@@ -58,7 +58,6 @@
           <a href="https://twitter.com/artichokeruby">
             <img
               alt="Twitter logo"
-              title="Twitter"
               width="40"
               height="40"
               src="social/twitter-logo.svg"
@@ -69,7 +68,6 @@
           <a href="https://github.com/artichoke">
             <img
               alt="GitHub logo"
-              title="GitHub"
               width="40"
               height="40"
               src="social/octicons-github-logo.svg"
@@ -80,7 +78,6 @@
           <a href="https://discord.gg/QCe2tp2">
             <img
               alt="Discord logo"
-              title="Discord"
               width="40"
               height="40"
               src="social/discord-logo.svg"
@@ -91,7 +88,6 @@
           <a href="https://hub.docker.com/u/artichokeruby">
             <img
               alt="Docker logo"
-              title="Docker Hub"
               width="40"
               height="40"
               src="social/docker-logo.svg"


### PR DESCRIPTION
Remove title attributes on all but Artichoke Ruby logos.