### PR TITLE
Fix copy for Docker image artifact description

### DIFF
--- a/src/install.html
+++ b/src/install.html
@@ -176,11 +176,7 @@
             Nightly builds of Artichoke are pushed to Docker Hub. Images are
             built on Ubuntu 18.04, Debian Buster Slim, and Alpine 3.
           </p>
-          <p>
-            These daily binaries track the latest trunk commit of Artichoke.
-            Binaries are also distributed through
-            <a href="https://github.com/rbenv/ruby-build">ruby-build</a>.
-          </p>
+          <p>These daily images track the latest trunk commit of Artichoke.</p>
           <a
             class="btn btn-lg btn-outline-info mb-3"
             href="https://hub.docker.com/r/artichokeruby/artichoke"


### PR DESCRIPTION
s/binaries/images/ and remove reference to ruby-build which is only relevant
to binary installs.