### PR TITLE
Add spinoso crate rustdoc to navbar

### DIFF
--- a/src/partials/nav.html
+++ b/src/partials/nav.html
@@ -78,9 +78,51 @@
               <div class="dropdown-divider"></div>
               <a
                 class="dropdown-item"
-                href="https://artichoke.github.io/artichoke/spec_runner/"
+                href="https://artichoke.github.io/artichoke/spinoso_array/"
               >
-                spec-runner
+                spionso-array
+              </a>
+              <a
+                class="dropdown-item"
+                href="https://artichoke.github.io/artichoke/spinoso_env/"
+              >
+                spionso-env
+              </a>
+              <a
+                class="dropdown-item"
+                href="https://artichoke.github.io/artichoke/spinoso_exception/"
+              >
+                spionso-exception
+              </a>
+              <a
+                class="dropdown-item"
+                href="https://artichoke.github.io/artichoke/spinoso_math/"
+              >
+                spionso-math
+              </a>
+              <a
+                class="dropdown-item"
+                href="https://artichoke.github.io/artichoke/spinoso_random/"
+              >
+                spionso-random
+              </a>
+              <a
+                class="dropdown-item"
+                href="https://artichoke.github.io/artichoke/spinoso_securerandom/"
+              >
+                spionso-securerandom
+              </a>
+              <a
+                class="dropdown-item"
+                href="https://artichoke.github.io/artichoke/spinoso_symbol/"
+              >
+                spionso-symbol
+              </a>
+              <a
+                class="dropdown-item"
+                href="https://artichoke.github.io/artichoke/spinoso_time/"
+              >
+                spionso-time
               </a>
             </div>
           </li>


### PR DESCRIPTION
Remove spec-runner since docs are no longer built. See artichoke/artichoke#849.