### PR TITLE
Spruce up webpack config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
           publish_branch: gh-pages
+          cname: www.artichokeruby.org
           user_name: artichoke-ci
           user_email: ci@artichokeruby.org
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1100,12 +1100,6 @@
         }
       }
     },
-    "cname-webpack-plugin": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cname-webpack-plugin/-/cname-webpack-plugin-3.0.0.tgz",
-      "integrity": "sha512-kL+C2Xwiev19vE5vOpVsUGelnGiebJtap6u9s29IsQ2cEoLcLmSeAiWI0aVsUTRzgOjnLuEmTu+MbqMDKVIjyw==",
-      "dev": true
-    },
     "coa": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
@@ -6081,6 +6075,17 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
+    "schema-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+      "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.6",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      }
+    },
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -6779,6 +6784,16 @@
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
+    },
+    "style-loader": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-2.0.0.tgz",
+      "integrity": "sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      }
     },
     "stylehacks": {
       "version": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "popper.js": "^1.16.1"
   },
   "devDependencies": {
-    "cname-webpack-plugin": "^3.0.0",
     "css-loader": "^5.0.1",
     "file-loader": "^6.2.0",
     "highlight.js": "^10.4.0",
@@ -35,6 +34,7 @@
     "optimize-css-assets-webpack-plugin": "^5.0.4",
     "sass": "^1.29.0",
     "sass-loader": "^10.1.0",
+    "style-loader": "^2.0.0",
     "svg-url-loader": "^7.1.1",
     "svgo": "^1.3.2",
     "svgo-loader": "^2.2.1",


### PR DESCRIPTION
- Remove `cname-webpack-plugin`.
- Set GitHub Pages CNAME with publish GitHub Action.
- Remove always-configured `HtmlWebpackPlugin` minify block.
  `HtmlWebpackPlugin` automatically enables a good set of minify
  settings when in `mode = production`.
- Dynamically set minification settings in `webpack.config.js` based on
  whether `mode == production`.
- Use `style-loader` when `mode != production`.

These learnings are being incorporated from artichoke/playground#237.