### PR TITLE
Update artichoke repo markdown links to point to trunk branch

### DIFF
--- a/src/install.html
+++ b/src/install.html
@@ -209,7 +209,7 @@
           </p>
           <a
             class="btn btn-lg btn-outline-dark mb-3"
-            href="https://github.com/artichoke/artichoke/blob/master/BUILD.md"
+            href="https://github.com/artichoke/artichoke/blob/trunk/BUILD.md"
           >
             Build Guide
           </a>

--- a/src/partials/footer.html
+++ b/src/partials/footer.html
@@ -23,7 +23,7 @@
         <li>
           <a
             class="text-muted"
-            href="https://github.com/artichoke/artichoke/blob/master/VISION.md"
+            href="https://github.com/artichoke/artichoke/blob/trunk/VISION.md"
           >
             Vision
           </a>


### PR DESCRIPTION
See https://github.com/artichoke/artichoke/pull/961, which transitions artichoke/artichoke's main branch to `trunk`.