### PR TITLE
Update cargo install instructions to declare 'trunk' branch

### DIFF
--- a/src/cargo-install.md
+++ b/src/cargo-install.md
@@ -1,3 +1,3 @@
 ```bash
-$ cargo install --git https://github.com/artichoke/artichoke --locked artichoke
+$ cargo install --git https://github.com/artichoke/artichoke --branch trunk --locked artichoke
 ```


### PR DESCRIPTION
See also rust-lang/cargo#3517.

Breakage caused by artichoke/artichoke#961.