### PR TITLE
Fix W3C HTML validation issues

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -197,10 +197,6 @@
     </div>
 
     <%= require('html-loader!./partials/footer.html') %>
-    <script
-      async
-      src="https://platform.twitter.com/widgets.js"
-      charset="utf-8"
-    ></script>
+    <script async src="https://platform.twitter.com/widgets.js"></script>
   </body>
 </html>

--- a/src/partials/nav.html
+++ b/src/partials/nav.html
@@ -23,10 +23,8 @@
     </button>
 
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
-      <ul class="navbar-nav ms-auto">
-        <div
-          class="container d-flex flex-column flex-md-row justify-content-end"
-        >
+      <div class="container d-flex flex-column flex-md-row justify-content-end">
+        <ul class="navbar-nav ms-auto">
           <li class="nav-item">
             <a class="nav-link" href="/install/">Install</a>
           </li>
@@ -47,87 +45,108 @@
               href="#"
               id="navbarDropdown"
               role="button"
-              data-toggle="dropdown"
-              aria-haspopup="true"
+              data-bs-toggle="dropdown"
               aria-expanded="false"
             >
               Docs
             </a>
-            <div
+            <ul
               class="dropdown-menu dropdown-menu-end"
               aria-labelledby="navbarDropdown"
             >
-              <a
-                class="dropdown-item"
-                href="https://artichoke.github.io/artichoke/artichoke/"
-              >
-                artichoke
-              </a>
-              <a
-                class="dropdown-item"
-                href="https://artichoke.github.io/artichoke/artichoke_core/"
-              >
-                artichoke-core
-              </a>
-              <a
-                class="dropdown-item"
-                href="https://artichoke.github.io/artichoke/artichoke_backend/"
-              >
-                artichoke-backend
-              </a>
-              <div class="dropdown-divider"></div>
-              <a
-                class="dropdown-item"
-                href="https://artichoke.github.io/artichoke/spinoso_array/"
-              >
-                spionso-array
-              </a>
-              <a
-                class="dropdown-item"
-                href="https://artichoke.github.io/artichoke/spinoso_env/"
-              >
-                spionso-env
-              </a>
-              <a
-                class="dropdown-item"
-                href="https://artichoke.github.io/artichoke/spinoso_exception/"
-              >
-                spionso-exception
-              </a>
-              <a
-                class="dropdown-item"
-                href="https://artichoke.github.io/artichoke/spinoso_math/"
-              >
-                spionso-math
-              </a>
-              <a
-                class="dropdown-item"
-                href="https://artichoke.github.io/artichoke/spinoso_random/"
-              >
-                spionso-random
-              </a>
-              <a
-                class="dropdown-item"
-                href="https://artichoke.github.io/artichoke/spinoso_securerandom/"
-              >
-                spionso-securerandom
-              </a>
-              <a
-                class="dropdown-item"
-                href="https://artichoke.github.io/artichoke/spinoso_symbol/"
-              >
-                spionso-symbol
-              </a>
-              <a
-                class="dropdown-item"
-                href="https://artichoke.github.io/artichoke/spinoso_time/"
-              >
-                spionso-time
-              </a>
-            </div>
+              <li>
+                <a
+                  class="dropdown-item"
+                  href="https://artichoke.github.io/artichoke/artichoke/"
+                >
+                  artichoke
+                </a>
+              </li>
+              <li>
+                <a
+                  class="dropdown-item"
+                  href="https://artichoke.github.io/artichoke/artichoke_core/"
+                >
+                  artichoke-core
+                </a>
+              </li>
+              <li>
+                <a
+                  class="dropdown-item"
+                  href="https://artichoke.github.io/artichoke/artichoke_backend/"
+                >
+                  artichoke-backend
+                </a>
+              </li>
+              <li class="dropdown-divider"></li>
+              <li>
+                <a
+                  class="dropdown-item"
+                  href="https://artichoke.github.io/artichoke/spinoso_array/"
+                >
+                  spionso-array
+                </a>
+              </li>
+              <li>
+                <a
+                  class="dropdown-item"
+                  href="https://artichoke.github.io/artichoke/spinoso_env/"
+                >
+                  spionso-env
+                </a>
+              </li>
+              <li>
+                <a
+                  class="dropdown-item"
+                  href="https://artichoke.github.io/artichoke/spinoso_exception/"
+                >
+                  spionso-exception
+                </a>
+              </li>
+              <li>
+                <a
+                  class="dropdown-item"
+                  href="https://artichoke.github.io/artichoke/spinoso_math/"
+                >
+                  spionso-math
+                </a>
+              </li>
+              <li>
+                <a
+                  class="dropdown-item"
+                  href="https://artichoke.github.io/artichoke/spinoso_random/"
+                >
+                  spionso-random
+                </a>
+              </li>
+              <li>
+                <a
+                  class="dropdown-item"
+                  href="https://artichoke.github.io/artichoke/spinoso_securerandom/"
+                >
+                  spionso-securerandom
+                </a>
+              </li>
+              <li>
+                <a
+                  class="dropdown-item"
+                  href="https://artichoke.github.io/artichoke/spinoso_symbol/"
+                >
+                  spionso-symbol
+                </a>
+              </li>
+              <li>
+                <a
+                  class="dropdown-item"
+                  href="https://artichoke.github.io/artichoke/spinoso_time/"
+                >
+                  spionso-time
+                </a>
+              </li>
+            </ul>
           </li>
-        </div>
-      </ul>
+        </ul>
+      </div>
     </div>
   </div>
 </nav>


### PR DESCRIPTION
- Do not nest `div` inside `ul` in `nav` partial.
- Remove obsolete `charset` property from Twitter embed script.
- Remove unlinked `aria-labelledby` property for docker SVG.
- Fix bootstrap nav dropdown data toggle property name. This regression was introduced in the upgrade to bootstrap@5.0.0-beta.1 #159.
- Use `ul` and `li` elements for nav dropdown.