### PR TITLE
Add devServer configuration to webpack.config.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -136,5 +136,10 @@ module.exports = (_env, argv) => {
     },
     plugins,
     optimization,
+    devServer: {
+      compress: true,
+      host: "127.0.0.1",
+      port: 8080,
+    },
   };
 };


### PR DESCRIPTION
Set host to localhost 127.0.0.1; browsers are marking this origin as trusted.
Set a port so it doesn't conflict with rubyconf's webpack config.