### PR TITLE
Modify webpack config to allow SVGs to be separate resources

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -110,7 +110,7 @@ module.exports = (_env, argv) => {
         {
           test: /\.svg$/,
           exclude: new RegExp(path.resolve(__dirname, "src", "assets")),
-          type: "asset/inline",
+          type: "asset",
           use: "svgo-loader",
           generator: {
             dataUrl: (content) => {


### PR DESCRIPTION
Modify the resource type of SVGs from `asset/inline` to `asset`. This
change causes the navbar logo to be generated as a separate SVG resource
since it is large. This avoids this large SVG from being embedded in the
index and install pages three times.