### PR TITLE
Fix quoting in prettier invocation for fmt npm run script

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "build": "webpack --mode production",
     "dev": "webpack serve --mode development",
     "dev:open": "webpack serve --mode development --open",
-    "fmt": "npx prettier --write '**/*'",
+    "fmt": "npx prettier --write \"**/*\"",
     "lint": "npx eslint --fix ."
   }
 }


### PR DESCRIPTION
Windows requires the glob to be double quoted.