### PR TITLE
Fix highlight.js deprecation warnings in markdown loader

### DIFF
--- a/loaders/markdown.js
+++ b/loaders/markdown.js
@@ -3,8 +3,11 @@ const marked = require("marked");
 
 marked.setOptions({
   renderer: new marked.Renderer(),
-  highlight: (code, lang) => {
-    const highlighted = hljs.highlight(lang, code, true);
+  highlight: (code, language) => {
+    const highlighted = hljs.highlight(code, {
+      language,
+      ignoreIllegals: true,
+    });
     const html = highlighted.value;
     return html;
   },


### PR DESCRIPTION
See #347.