### PR TITLE
Add npm start script that invokes npm:build and npm:serve

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "dev": "npx chokidar-cli \"src/**/*\" \"package.json\" \"package-lock.json\" \"webpack.config.*\" -c \"npm run build\" --initial",
     "fmt": "npx prettier --write \"**/*\"",
     "lint": "npx eslint --fix .",
-    "serve": "python -m http.server --directory dist --bind 127.0.0.1 8080"
+    "serve": "python -m http.server --directory dist --bind 127.0.0.1 8080",
+    "start": "npx concurrently \"npm:build\" \"npm:serve\""
   }
 }


### PR DESCRIPTION
Improve the local development experience by not requiring multiple terminal windows.