### PR TITLE
Update `serve` and `start` npm run-scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "dev": "npx chokidar-cli \"src/**/*\" \"package.json\" \"package-lock.json\" \"webpack.config.*\" -c \"npm run build\" --initial",
     "fmt": "npx prettier --write \"**/*\"",
     "lint": "npx eslint --fix .",
-    "serve": "python -m http.server --directory dist --bind 127.0.0.1 8080",
+    "serve": "python3 -u -m http.server --directory dist --bind 127.0.0.1 0",
     "start": "npx concurrently \"npm:build\" \"npm:serve\""
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     "fmt": "npx prettier --write \"**/*\"",
     "lint": "npx eslint --fix .",
     "serve": "python3 -u -m http.server --directory dist --bind 127.0.0.1 0",
-    "start": "npx concurrently \"npm:build\" \"npm:serve\""
+    "start": "npx concurrently \"npm:dev\" \"npm:serve\""
   }
 }


### PR DESCRIPTION
Update the `serve` npm run-script to:

```sh
python3 -u -m http.server --directory dist --bind 127.0.0.1 0
```

- Invoke `python3` instead of `python`
- Pass `-u` for unbuffered output to ensure logs get flushed to
  `concurrently`.
- Pass `0` for port to allow the OS to pick any free port.

Update the `start` npm run-script to:

```sh
npx concurrently "npm:dev" "npm:serve"
```

so the site is recompiled in the dev loop.

## `npm start`

now outputs like this:

```console
$ npm start

> @artichokeruby/www.artichokeruby.org@0.4.0 start
> npx concurrently "npm:build" "npm:serve"

[build]
[build] > @artichokeruby/www.artichokeruby.org@0.4.0 build
[build] > node bin/webpack-build.js
[build]
[serve]
[serve] > @artichokeruby/www.artichokeruby.org@0.4.0 serve
[serve] > python3 -u -m http.server --directory dist --bind 127.0.0.1 0
[serve]
[serve] Serving HTTP on 127.0.0.1 port 61658 (http://127.0.0.1:61658/) ...
```