### PR TITLE
Run eslint with 'npm run lint' in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
         run: npm ci
 
       - name: Lint with eslint
-        run: npx eslint .
+        run: npm run lint
 
   text:
     name: Lint and format text


### PR DESCRIPTION
Delegate to the npm run script in CI which is more likely to be updated since it is used in the local development loop.