### PR TITLE
Reformat with prettier 2.5

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -121,13 +121,7 @@
       <div class="row mb-5 pb-md-4 align-items-center">
         <div class="col-md-5">
           <div
-            class="
-              masthead-followup-icon
-              d-inline-block
-              mb-2
-              text-white
-              bg-artichoke
-            "
+            class="masthead-followup-icon d-inline-block mb-2 text-white bg-artichoke"
           >
             <img alt="Ruby logo" width="32" height="32" src="/logos/ruby.svg" />
           </div>
@@ -155,13 +149,7 @@
       <div class="row mb-5 pb-md-4 align-items-center">
         <div class="col-md-5">
           <div
-            class="
-              masthead-followup-icon
-              d-inline-block
-              mb-2
-              text-white
-              bg-dark
-            "
+            class="masthead-followup-icon d-inline-block mb-2 text-white bg-dark"
           >
             <img
               alt="Twitter logo"

--- a/src/install.html
+++ b/src/install.html
@@ -118,13 +118,7 @@
       <div id="nightly" class="row mb-5 pb-md-4 align-items-center">
         <div class="col-md-5">
           <div
-            class="
-              masthead-followup-icon
-              d-inline-block
-              mb-2
-              text-white
-              bg-nightly
-            "
+            class="masthead-followup-icon d-inline-block mb-2 text-white bg-nightly"
           >
             <svg
               width="32"
@@ -168,13 +162,7 @@
       <div id="docker" class="row mb-5 pb-md-4 align-items-center">
         <div class="col-md-5">
           <div
-            class="
-              masthead-followup-icon
-              d-inline-block
-              mb-2
-              text-white
-              bg-info
-            "
+            class="masthead-followup-icon d-inline-block mb-2 text-white bg-info"
           >
             <svg
               viewBox="0 0 24 24"
@@ -206,13 +194,7 @@
       <div id="cargo" class="row mb-5 pb-md-4 align-items-center">
         <div class="col-md-5">
           <div
-            class="
-              masthead-followup-icon
-              d-inline-block
-              mb-2
-              text-white
-              bg-cargo
-            "
+            class="masthead-followup-icon d-inline-block mb-2 text-white bg-cargo"
           >
             <img alt="Rust Cargo logo" width="32" src="/logos/cargo.svg" />
           </div>


### PR DESCRIPTION
https://prettier.io/blog/2021/11/25/2.5.0.html

Specifically this PR updates according to changes in CSS class line breaking:

https://prettier.io/blog/2021/11/25/2.5.0.html#collapse-html-class-attributes-onto-one-line-11827httpsgithubcomprettierprettierpull11827-by-jlongsterhttpsgithubcomjlongster