### PR TITLE
Apply frontendchecklist.io best practices to project website

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,25 +1,31 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" dir="ltr">
   <head>
     <meta charset="utf-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
     />
-    <meta name="description" content="Artichoke is a Ruby made with Rust." />
-    <meta name="author" content="Ryan Lopopolo" />
 
     <title>Artichoke Ruby</title>
+
+    <meta name="description" content="Artichoke is a Ruby made with Rust." />
+
+    <link rel="dns-prefetch" href="//www.googletagmanager.com" />
+    <link rel="dns-prefetch" href="//platform.twitter.com" />
+    <link rel="preconnect" href="https://www.googletagmanager.com" />
+    <link rel="preconnect" href="https://platform.twitter.com" />
 
     <link rel="preload" href="/main.bundle.css" as="style" />
     <link rel="preload" href="/main.bundle.js" as="script" />
     <link rel="preload" href="/artichoke-logo.svg" as="image" />
 
-    <link rel="canonical" href="https://www.artichokeruby.org/" />
-    <link rel="stylesheet" href="/main.bundle.css" />
-
     <!-- Favicons -->
     <%~ includeFile("partials/favicons.html") %>
+
+    <link rel="canonical" href="https://www.artichokeruby.org/" />
+
+    <link rel="stylesheet" href="/main.bundle.css" />
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image" />
@@ -77,7 +83,7 @@
             <img
               class="mw-100 d-block mx-auto"
               title="Artichoke Ruby"
-              alt="Artichoke Ruby logo"
+              alt="Artichoke Ruby."
               src="/artichoke-logo.svg"
             />
           </div>
@@ -123,7 +129,7 @@
           <div
             class="masthead-followup-icon d-inline-block mb-2 text-white bg-artichoke"
           >
-            <img alt="Ruby logo" width="32" height="32" src="/logos/ruby.svg" />
+            <img alt="Ruby." width="32" height="32" src="/logos/ruby.svg" />
           </div>
           <h2 class="display-5 font-weight-normal">Install</h2>
           <p class="lead font-weight-normal">
@@ -152,7 +158,7 @@
             class="masthead-followup-icon d-inline-block mb-2 text-white bg-dark"
           >
             <img
-              alt="Twitter logo"
+              alt="Twitter."
               width="32"
               height="32"
               src="/social/twitter-logo-blue.svg"

--- a/src/install.html
+++ b/src/install.html
@@ -1,28 +1,32 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" dir="ltr">
   <head>
     <meta charset="utf-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
     />
+
+    <title>Install Artichoke – Artichoke Ruby</title>
+
     <meta
       name="description"
       content="Install Artichoke Ruby, a Ruby made with Rust."
     />
-    <meta name="author" content="Ryan Lopopolo" />
 
-    <title>Install Artichoke – Artichoke Ruby</title>
+    <link rel="dns-prefetch" href="//www.googletagmanager.com" />
+    <link rel="preconnect" href="https://www.googletagmanager.com" />
 
     <link rel="preload" href="/main.bundle.css" as="style" />
     <link rel="preload" href="/main.bundle.js" as="script" />
     <link rel="preload" href="/artichoke-logo.svg" as="image" />
 
-    <link rel="canonical" href="https://www.artichokeruby.org/install/" />
-    <link rel="stylesheet" href="/main.bundle.css" />
-
     <!-- Favicons -->
     <%~ includeFile("partials/favicons.html") %>
+
+    <link rel="canonical" href="https://www.artichokeruby.org/install/" />
+
+    <link rel="stylesheet" href="/main.bundle.css" />
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image" />
@@ -80,7 +84,7 @@
             <img
               class="mw-100 d-block mx-auto"
               title="Artichoke Ruby"
-              alt="Artichoke Ruby logo"
+              alt="Artichoke Ruby."
               src="/artichoke-logo.svg"
             />
           </div>
@@ -127,6 +131,8 @@
               class="bi bi-moon"
               fill="currentColor"
               xmlns="http://www.w3.org/2000/svg"
+              role="img"
+              aria-label="Midnight moon."
             >
               <path
                 fill-rule="evenodd"
@@ -168,6 +174,8 @@
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
               width="32"
+              role="img"
+              aria-label="Docker."
             >
               <path
                 d="M4.82 17.275c-.684 0-1.304-.56-1.304-1.24s.56-1.243 1.305-1.243c.748 0 1.31.56 1.31 1.242s-.622 1.24-1.305 1.24zm16.012-6.763c-.135-.992-.75-1.8-1.56-2.42l-.315-.25-.254.31c-.494.56-.69 1.553-.63 2.295.06.562.24 1.12.554 1.554-.254.13-.568.25-.81.377a5.29 5.29 0 01-1.68.25H.097l-.06.37a6.98 6.98 0 00.562 3.54l.244.435v.06c1.5 2.483 4.17 3.6 7.078 3.6 5.594 0 10.182-2.42 12.357-7.633 1.425.062 2.864-.31 3.54-1.676l.18-.31-.3-.187c-.81-.494-1.92-.56-2.85-.31l-.018.002zm-8.008-.992h-2.428v2.42h2.43V9.518l-.002.003zm0-3.043h-2.428v2.42h2.43V6.48l-.002-.003zm0-3.104h-2.428v2.42h2.43v-2.42h-.002zm2.97 6.147H13.38v2.42h2.42V9.518l-.007.003zm-8.998 0H4.383v2.42h2.422V9.518l-.01.003zm3.03 0h-2.4v2.42H9.84V9.518l-.015.003zm-6.03 0H1.4v2.42h2.428V9.518l-.03.003zm6.03-3.043h-2.4v2.42H9.84V6.48l-.015-.003zm-3.045 0H4.387v2.42H6.8V6.48l-.016-.003z"
@@ -196,7 +204,7 @@
           <div
             class="masthead-followup-icon d-inline-block mb-2 text-white bg-cargo"
           >
-            <img alt="Rust Cargo logo" width="32" src="/logos/cargo.svg" />
+            <img alt="Rust Cargo." width="32" src="/logos/cargo.svg" />
           </div>
           <h2 class="display-5 font-weight-normal">Using Cargo</h2>
           <p class="lead font-weight-normal">

--- a/src/partials/footer.html
+++ b/src/partials/footer.html
@@ -45,7 +45,7 @@
         <li class="list-inline-item">
           <a href="https://twitter.com/artichokeruby">
             <img
-              alt="Twitter logo"
+              alt="Twitter."
               width="40"
               height="40"
               src="/social/twitter-logo-black.svg"
@@ -55,7 +55,7 @@
         <li class="list-inline-item">
           <a href="https://github.com/artichoke">
             <img
-              alt="GitHub logo"
+              alt="GitHub."
               width="40"
               height="40"
               src="/social/github-logo.svg"
@@ -65,7 +65,7 @@
         <li class="list-inline-item">
           <a href="https://discord.gg/QCe2tp2">
             <img
-              alt="Discord logo"
+              alt="Discord."
               width="40"
               height="40"
               src="/social/discord-logo.svg"
@@ -78,9 +78,9 @@
     <div class="col-12 px-0">
       <a href="/" aria-label="Artichoke Ruby">
         <img
-          height="64"
+          alt="Artichoke Ruby."
           title="Artichoke Ruby"
-          alt="Artichoke Ruby logo"
+          height="64"
           src="/wordmark-black.svg"
         />
       </a>

--- a/src/partials/nav.html
+++ b/src/partials/nav.html
@@ -2,10 +2,10 @@
   <div class="container d-flex flex-row justify-content-between">
     <a class="navbar-brand" href="/" aria-label="Artichoke Ruby">
       <img
+        alt="Artichoke Ruby."
+        title="Artichoke Ruby"
         class="float-start"
         height="40"
-        title="Artichoke Ruby"
-        alt="Artichoke Ruby logo"
         src="/nav-white.svg"
       />
     </a>


### PR DESCRIPTION
- Add `dir="ltr"` attribute to `html` element.
- Properly declare viewport.
- Remove meta `author` tag.
- Move meta `description` tag below `title`.
- Add DNS prefetching for Google Tag Manager and Twitter embed asset domains.
- Add HTTPS preconnect for Google Tag Manager and Twitter embed asset domains.
- Move favicons partial above stylesheets.
- Add period (".") to the end of image alt-text to encourage screen readers to pause.
- Reduce alt-text for logos to just the company name.
- Add `role="img"` + `aria-label` to inline SVG elements to add alt-text.

Followup to #444.