### PR TITLE
Remove unused preloads, preload twitter widgets

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -17,8 +17,12 @@
     <link rel="preconnect" href="https://platform.twitter.com" />
 
     <link rel="preload" href="/main.bundle.css" as="style" />
-    <link rel="preload" href="/main.bundle.js" as="script" />
     <link rel="preload" href="/artichoke-logo.svg" as="image" />
+    <link
+      rel="preload"
+      href="https://platform.twitter.com/widgets.js"
+      as="script"
+    />
 
     <!-- Favicons -->
     <%~ includeFile("partials/favicons.html") %>

--- a/src/install.html
+++ b/src/install.html
@@ -18,7 +18,6 @@
     <link rel="preconnect" href="https://www.googletagmanager.com" />
 
     <link rel="preload" href="/main.bundle.css" as="style" />
-    <link rel="preload" href="/main.bundle.js" as="script" />
     <link rel="preload" href="/artichoke-logo.svg" as="image" />
 
     <!-- Favicons -->


### PR DESCRIPTION
These warnings appear in the console in prod:

- A preload for 'https://www.artichokeruby.org/main.bundle.js' is found,
  but is not used because the request credentials mode does not match.
  Consider taking a look at crossorigin attribute.
- The resource https://www.artichokeruby.org/main.bundle.js was preloaded
  using link preload but not used within a few seconds from the window's
  load event. Please make sure it has an appropriate `as` value and it is
  preloaded intentionally.

Preloads of the JavaScript bundle are not necessary since this code is
only used for the nav drop downs, which are not render blocking.

Add a preload for Twitter widget JavaScript on the home page since this
JS is render blocking and causes layout shift.