### PR TITLE
Update 'Docker images' section on install page to refer to current container base image versions

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -44,7 +44,7 @@
     "docker": {
       "go": "Docker",
       "title": "Docker images",
-      "content": "Nightly builds of Artichoke are pushed to Docker Hub. Images are built on Ubuntu 18.04, Debian Buster Slim, and Alpine 3.",
+      "content": "Nightly builds of Artichoke are pushed to Docker Hub. Images are built on Ubuntu 18.04, Debian Bullseye Slim, and Alpine 3.",
       "hint": "These daily images track the latest trunk commit of Artichoke.",
       "button": "Docker Hub"
     },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -44,7 +44,7 @@
     "docker": {
       "go": "Docker",
       "title": "Docker images",
-      "content": "Nightly builds of Artichoke are pushed to Docker Hub. Images are built on Ubuntu 18.04, Debian Bullseye Slim, and Alpine 3.",
+      "content": "Nightly builds of Artichoke are pushed to Docker Hub. Images are built on Ubuntu 20.04, Debian Bullseye Slim, and Alpine 3.",
       "hint": "These daily images track the latest trunk commit of Artichoke.",
       "button": "Docker Hub"
     },

--- a/src/locales/zh-hans.json
+++ b/src/locales/zh-hans.json
@@ -43,7 +43,7 @@
     "docker": {
       "go": "Docker",
       "title": "Docker镜像",
-      "content": "Artichoke的nightly构建会被推送至Docker Hub。镜像的构建基于Ubuntu 18.04、Debian Bullseye Slim和Alpine 3。",
+      "content": "Artichoke的nightly构建会被推送至Docker Hub。镜像的构建基于Ubuntu 20.04、Debian Bullseye Slim和Alpine 3。",
       "hint": "这些每日镜像包含了Artichoke的最新trunk commit。",
       "button": "Docker Hub"
     },

--- a/src/locales/zh-hans.json
+++ b/src/locales/zh-hans.json
@@ -43,7 +43,7 @@
     "docker": {
       "go": "Docker",
       "title": "Docker镜像",
-      "content": "Artichoke的nightly构建会被推送至Docker Hub。镜像的构建基于Ubuntu 18.04、Debian Buster Slim和Alpine 3。",
+      "content": "Artichoke的nightly构建会被推送至Docker Hub。镜像的构建基于Ubuntu 18.04、Debian Bullseye Slim和Alpine 3。",
       "hint": "这些每日镜像包含了Artichoke的最新trunk commit。",
       "button": "Docker Hub"
     },


### PR DESCRIPTION
Nightly Docker images have been built with Debian 11 Bullseye since April 2021:

- https://github.com/artichoke/docker-artichoke-nightly/pull/37

Nightly Docker images have been built with Ubuntu 20.04 Focal since April 2021:

- https://github.com/artichoke/docker-artichoke-nightly/pull/38