### PR TITLE
Localize Twitter embeds and meta links

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -27,7 +27,10 @@
     <!-- Favicons -->
     <%~ includeFile("partials/favicons.html") %>
 
-    <link rel="canonical" href="https://www.artichokeruby.org/" />
+    <link
+      rel="canonical"
+      href="https://www.artichokeruby.org<%= it.locale.links.home %>"
+    />
 
     <link rel="stylesheet" href="/main.bundle.css" />
 
@@ -46,7 +49,10 @@
     />
 
     <!-- Facebook Open Graph metadata -->
-    <meta property="og:url" content="https://www.artichokeruby.org/" />
+    <meta
+      property="og:url"
+      content="https://www.artichokeruby.org<%= it.locale.links.home %>"
+    />
     <meta property="og:site_name" content="artichokeruby.org" />
     <meta property="og:title" content="<%= it.t.index.head.title %>" />
     <meta
@@ -68,8 +74,8 @@
     <a class="visually-hidden visually-hidden-focusable" href="#content">
       <%= it.t.skip_to_main %>
     </a>
-    <%~ includeFile("partials/nav.html", { page: "index", pageSlug: "", t:
-    it.t.nav, prefix: it.prefix }) %>
+    <%~ includeFile("partials/nav.html", { page: "home", t: it.t.nav, locale:
+    it.locale, locales: it.locales }) %>
 
     <!--
       This layout is heavily inspired by the Bootstrap v5 docs homepage, which
@@ -104,7 +110,7 @@
                 <%= it.t.index.contribute %>
               </a>
               <a
-                href="<%= it.prefix + '/install/' %>"
+                href="<%= it.locale.links.install %>"
                 class="btn btn-lg btn-outline-secondary mb-3"
               >
                 <%= it.t.index.install.title %>
@@ -141,7 +147,7 @@
           <p><%= it.t.index.install.hint %></p>
           <a
             class="btn btn-lg btn-outline-primary mb-3"
-            href="<%= it.prefix + '/install/' %>"
+            href="<%= it.locale.links.install %>"
           >
             <%= it.t.index.install.guide %>
           </a>
@@ -178,6 +184,7 @@
             href="https://twitter.com/artichokeruby?ref_src=twsrc%5Etfw"
             class="twitter-follow-button"
             data-size="large"
+            data-lang="<%= it.locale.twitter %>"
             data-show-count="false"
           >
             Follow @artichokeruby
@@ -186,8 +193,8 @@
         <div class="col-md-7 ps-md-5">
           <a
             class="twitter-timeline"
+            data-lang="<%= it.locale.twitter %>"
             data-height="500"
-            data-theme="light"
             href="https://twitter.com/artichokeruby?ref_src=twsrc%5Etfw"
           >
             Tweets by artichokeruby

--- a/src/install.html
+++ b/src/install.html
@@ -20,7 +20,10 @@
     <!-- Favicons -->
     <%~ includeFile("partials/favicons.html") %>
 
-    <link rel="canonical" href="https://www.artichokeruby.org/install/" />
+    <link
+      rel="canonical"
+      href="https://www.artichokeruby.org<%= it.locale.links.install %>"
+    />
 
     <link rel="stylesheet" href="/main.bundle.css" />
 
@@ -39,7 +42,10 @@
     />
 
     <!-- Facebook Open Graph metadata -->
-    <meta property="og:url" content="https://www.artichokeruby.org/install/" />
+    <meta
+      property="og:url"
+      content="https://www.artichokeruby.org<%= it.locale.links.install %>"
+    />
     <meta property="og:site_name" content="artichokeruby.org" />
     <meta property="og:title" content="<%= it.t.install.head.title %>" />
     <meta
@@ -61,8 +67,8 @@
     <a class="visually-hidden visually-hidden-focusable" href="#content">
       <%= it.t.skip_to_main %>
     </a>
-    <%~ includeFile("partials/nav.html", { page: "install", pageSlug: "install",
-    t: it.t.nav, prefix: it.prefix }) %>
+    <%~ includeFile("partials/nav.html", { page: "install", t: it.t.nav, locale:
+    it.locale, locales: it.locales }) %>
 
     <!--
       This layout is heavily inspired by the Bootstrap v5 docs homepage, which

--- a/src/partials/nav.html
+++ b/src/partials/nav.html
@@ -2,7 +2,7 @@
   <div class="container d-flex flex-row justify-content-between">
     <a
       class="navbar-brand"
-      href="<%= it.prefix + '/' %>"
+      href="<%= it.locale.links.home %>"
       aria-label="Artichoke Ruby"
     >
       <img
@@ -29,13 +29,13 @@
       <ul class="navbar-nav ms-auto">
         <li class="nav-item">
           <!-- prettier-ignore -->
-          <a class="nav-link <% if (it.page === 'index') { %> active" aria-current="page" <% } else { %> " <% } %> href="<%= it.prefix + '/' %>">
+          <a class="nav-link <% if (it.page === 'home') { %> active" aria-current="page" <% } else { %> " <% } %> href="<%= it.locale.links.home %>">
             <%= it.t.home %>
           </a>
         </li>
         <li class="nav-item">
           <!-- prettier-ignore -->
-          <a class="nav-link <% if (it.page === 'install') { %> active" aria-current="page" <% } else { %> " <% } %> href="<%= it.prefix + '/install/' %>">
+          <a class="nav-link <% if (it.page === 'install') { %> active" aria-current="page" <% } else { %> " <% } %> href="<%= it.locale.links.install %>">
             <%= it.t.install %>
           </a>
         </li>
@@ -204,13 +204,13 @@
             <li>
               <a
                 class="dropdown-item"
-                href="/<%= it.pageSlug === '' ? '' : `${it.pageSlug}/` %>"
+                href="<%= it.locales['en'].links[it.page] %>"
               >
                 English
               </a>
               <a
                 class="dropdown-item"
-                href="/zh-hans/<%= it.pageSlug === '' ? '' : `${it.pageSlug}/` %>"
+                href="<%= it.locales['zh-hans'].links[it.page] %>"
               >
                 中文
               </a>


### PR DESCRIPTION
Followup to:

- #449
- #472

Changes:

- Localize Twitter embed widget language.
- Rework how locales are set up in `build.mjs`.
- Pre-compute the URL paths for all links per locale and refer to links with named aliases in HTML templates.
- Resolve langauge selector links using locale objects.
- Rework build script directory creation to use locale path prefixes.
- Mark the `en` locale as the default and all other locales as not default.
- Use locale-specific links for `rel="canonical"` link tags.
- Use locale-specific links for `og:url` meta tags.