### PR TITLE
Remove unused `bootstrap-icons` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
       "dependencies": {
         "@artichokeruby/logo": "^0.12.0",
         "@popperjs/core": "^2.11.4",
-        "bootstrap": "^5.1.3",
-        "bootstrap-icons": "^1.8.1"
+        "bootstrap": "^5.1.3"
       },
       "devDependencies": {
         "@minify-html/js": "^0.8.0",
@@ -66,14 +65,6 @@
       },
       "peerDependencies": {
         "@popperjs/core": "^2.10.2"
-      }
-    },
-    "node_modules/bootstrap-icons": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.8.1.tgz",
-      "integrity": "sha512-IXUqislddPJfwq6H+2nTkHyr9epO9h6u1AG0OZCx616w+TgzeoCjfmI3qJMQqt1J586gN2IxzB4M99Ip4sTZ1w==",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/brace-expansion": {
@@ -687,11 +678,6 @@
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
       "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
       "requires": {}
-    },
-    "bootstrap-icons": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.8.1.tgz",
-      "integrity": "sha512-IXUqislddPJfwq6H+2nTkHyr9epO9h6u1AG0OZCx616w+TgzeoCjfmI3qJMQqt1J586gN2IxzB4M99Ip4sTZ1w=="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
   "dependencies": {
     "@artichokeruby/logo": "^0.12.0",
     "@popperjs/core": "^2.11.4",
-    "bootstrap": "^5.1.3",
-    "bootstrap-icons": "^1.8.1"
+    "bootstrap": "^5.1.3"
   },
   "devDependencies": {
     "@minify-html/js": "^0.8.0",

--- a/src/install.html
+++ b/src/install.html
@@ -139,6 +139,12 @@
           <div
             class="masthead-followup-icon d-inline-block mb-2 text-white bg-nightly"
           >
+            <!--
+              This icon is originally sourced from the `bootstrap-icons` project.
+              License: https://github.com/twbs/icons/blob/v1.3.0/LICENSE.md
+              Copyright (c) 2019-2020 The Bootstrap Authors
+              Source: https://github.com/twbs/icons/blob/v1.3.0/icons/moon.svg
+            -->
             <svg
               width="32"
               height="32"


### PR DESCRIPTION
Add attribution notice to source where icon was sourced from (upstream has since diverged).