### PR TITLE
Rollup of September 2022 dependabot npm updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,15 +10,15 @@
       "license": "MIT",
       "dependencies": {
         "@artichokeruby/logo": "^0.12.0",
-        "@popperjs/core": "^2.11.5",
+        "@popperjs/core": "^2.11.6",
         "bootstrap": "^5.2.0"
       },
       "devDependencies": {
-        "@minify-html/node": "^0.9.2",
-        "esbuild": "^0.14.53",
+        "@minify-html/node": "^0.10.0",
+        "esbuild": "^0.15.6",
         "eta": "^1.12.3",
         "highlight.js": "^11.6.0",
-        "marked": "^4.0.18",
+        "marked": "^4.1.0",
         "purgecss": "^4.1.3"
       }
     },
@@ -28,9 +28,9 @@
       "integrity": "sha512-VzsxlZPdsXaSfwFuUljVIr6YHjvHxWCwvURKRJq8GcP22XEnq+gGVP7ByVMJW9SL9cUH3eLPKwSsh9KH3W002w=="
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.53.tgz",
-      "integrity": "sha512-W2dAL6Bnyn4xa/QRSU3ilIK4EzD5wgYXKXJiS1HDF5vU3675qc2bvFyLwbUcdmssDveyndy7FbitrCoiV/eMLg==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.6.tgz",
+      "integrity": "sha512-hqmVU2mUjH6J2ZivHphJ/Pdse2ZD+uGCHK0uvsiLDk/JnSedEVj77CiVUnbMKuU4tih1TZZL8tG9DExQg/GZsw==",
       "cpu": [
         "loong64"
       ],
@@ -44,9 +44,9 @@
       }
     },
     "node_modules/@minify-html/node": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@minify-html/node/-/node-0.9.2.tgz",
-      "integrity": "sha512-qXu2s34R9UgdBaofrF1OwEQXhVNsR9gK8knpQF2zSl00XFgiUKinfk6zyQu29Cwy2X4wPtOhzbg5K+vjyZnvQw==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@minify-html/node/-/node-0.10.0.tgz",
+      "integrity": "sha512-qbTIPTrHEeFJ52bXvFxKFkY5NGir0vWrT4jri5DIo6awQJX1gK5m5ST4l2Z7SK94HrhjHhg6GZoDbS0nK2VW0w==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/@popperjs/core": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
-      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
+      "version": "2.11.6",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
+      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -139,9 +139,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.53.tgz",
-      "integrity": "sha512-ohO33pUBQ64q6mmheX1mZ8mIXj8ivQY/L4oVuAshr+aJI+zLl+amrp3EodrUNDNYVrKJXGPfIHFGhO8slGRjuw==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.6.tgz",
+      "integrity": "sha512-sgLOv3l4xklvXzzczhRwKRotyrfyZ2i1fCS6PTOLPd9wevDPArGU8HFtHrHCOcsMwTjLjzGm15gvC8uxVzQf+w==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -151,33 +151,33 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/linux-loong64": "0.14.53",
-        "esbuild-android-64": "0.14.53",
-        "esbuild-android-arm64": "0.14.53",
-        "esbuild-darwin-64": "0.14.53",
-        "esbuild-darwin-arm64": "0.14.53",
-        "esbuild-freebsd-64": "0.14.53",
-        "esbuild-freebsd-arm64": "0.14.53",
-        "esbuild-linux-32": "0.14.53",
-        "esbuild-linux-64": "0.14.53",
-        "esbuild-linux-arm": "0.14.53",
-        "esbuild-linux-arm64": "0.14.53",
-        "esbuild-linux-mips64le": "0.14.53",
-        "esbuild-linux-ppc64le": "0.14.53",
-        "esbuild-linux-riscv64": "0.14.53",
-        "esbuild-linux-s390x": "0.14.53",
-        "esbuild-netbsd-64": "0.14.53",
-        "esbuild-openbsd-64": "0.14.53",
-        "esbuild-sunos-64": "0.14.53",
-        "esbuild-windows-32": "0.14.53",
-        "esbuild-windows-64": "0.14.53",
-        "esbuild-windows-arm64": "0.14.53"
+        "@esbuild/linux-loong64": "0.15.6",
+        "esbuild-android-64": "0.15.6",
+        "esbuild-android-arm64": "0.15.6",
+        "esbuild-darwin-64": "0.15.6",
+        "esbuild-darwin-arm64": "0.15.6",
+        "esbuild-freebsd-64": "0.15.6",
+        "esbuild-freebsd-arm64": "0.15.6",
+        "esbuild-linux-32": "0.15.6",
+        "esbuild-linux-64": "0.15.6",
+        "esbuild-linux-arm": "0.15.6",
+        "esbuild-linux-arm64": "0.15.6",
+        "esbuild-linux-mips64le": "0.15.6",
+        "esbuild-linux-ppc64le": "0.15.6",
+        "esbuild-linux-riscv64": "0.15.6",
+        "esbuild-linux-s390x": "0.15.6",
+        "esbuild-netbsd-64": "0.15.6",
+        "esbuild-openbsd-64": "0.15.6",
+        "esbuild-sunos-64": "0.15.6",
+        "esbuild-windows-32": "0.15.6",
+        "esbuild-windows-64": "0.15.6",
+        "esbuild-windows-arm64": "0.15.6"
       }
     },
     "node_modules/esbuild-android-64": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.53.tgz",
-      "integrity": "sha512-fIL93sOTnEU+NrTAVMIKiAw0YH22HWCAgg4N4Z6zov2t0kY9RAJ50zY9ZMCQ+RT6bnOfDt8gCTnt/RaSNA2yRA==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.6.tgz",
+      "integrity": "sha512-Z1CHSgB1crVQi2LKSBwSkpaGtaloVz0ZIYcRMsvHc3uSXcR/x5/bv9wcZspvH/25lIGTaViosciS/NS09ERmVA==",
       "cpu": [
         "x64"
       ],
@@ -191,9 +191,9 @@
       }
     },
     "node_modules/esbuild-android-arm64": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.53.tgz",
-      "integrity": "sha512-PC7KaF1v0h/nWpvlU1UMN7dzB54cBH8qSsm7S9mkwFA1BXpaEOufCg8hdoEI1jep0KeO/rjZVWrsH8+q28T77A==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.6.tgz",
+      "integrity": "sha512-mvM+gqNxqKm2pCa3dnjdRzl7gIowuc4ga7P7c3yHzs58Im8v/Lfk1ixSgQ2USgIywT48QWaACRa3F4MG7djpSw==",
       "cpu": [
         "arm64"
       ],
@@ -207,9 +207,9 @@
       }
     },
     "node_modules/esbuild-darwin-64": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.53.tgz",
-      "integrity": "sha512-gE7P5wlnkX4d4PKvLBUgmhZXvL7lzGRLri17/+CmmCzfncIgq8lOBvxGMiQ4xazplhxq+72TEohyFMZLFxuWvg==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.6.tgz",
+      "integrity": "sha512-BsfVt3usScAfGlXJiGtGamwVEOTM8AiYiw1zqDWhGv6BncLXCnTg1As+90mxWewdTZKq3iIy8s9g8CKkrrAXVw==",
       "cpu": [
         "x64"
       ],
@@ -223,9 +223,9 @@
       }
     },
     "node_modules/esbuild-darwin-arm64": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.53.tgz",
-      "integrity": "sha512-otJwDU3hnI15Q98PX4MJbknSZ/WSR1I45il7gcxcECXzfN4Mrpft5hBDHXNRnCh+5858uPXBXA1Vaz2jVWLaIA==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.6.tgz",
+      "integrity": "sha512-CnrAeJaEpPakUobhqO4wVSA4Zm6TPaI5UY4EsI62j9mTrjIyQPXA1n4Ju6Iu5TVZRnEqV6q8blodgYJ6CJuwCA==",
       "cpu": [
         "arm64"
       ],
@@ -239,9 +239,9 @@
       }
     },
     "node_modules/esbuild-freebsd-64": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.53.tgz",
-      "integrity": "sha512-WkdJa8iyrGHyKiPF4lk0MiOF87Q2SkE+i+8D4Cazq3/iqmGPJ6u49je300MFi5I2eUsQCkaOWhpCVQMTKGww2w==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.6.tgz",
+      "integrity": "sha512-+qFdmqi+jkAsxsNJkaWVrnxEUUI50nu6c3MBVarv3RCDCbz7ZS1a4ZrdkwEYFnKcVWu6UUE0Kkb1SQ1yGEG6sg==",
       "cpu": [
         "x64"
       ],
@@ -255,9 +255,9 @@
       }
     },
     "node_modules/esbuild-freebsd-arm64": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.53.tgz",
-      "integrity": "sha512-9T7WwCuV30NAx0SyQpw8edbKvbKELnnm1FHg7gbSYaatH+c8WJW10g/OdM7JYnv7qkimw2ZTtSA+NokOLd2ydQ==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.6.tgz",
+      "integrity": "sha512-KtQkQOhnNciXm2yrTYZMD3MOm2zBiiwFSU+dkwNbcfDumzzUprr1x70ClTdGuZwieBS1BM/k0KajRQX7r504Xw==",
       "cpu": [
         "arm64"
       ],
@@ -271,9 +271,9 @@
       }
     },
     "node_modules/esbuild-linux-32": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.53.tgz",
-      "integrity": "sha512-VGanLBg5en2LfGDgLEUxQko2lqsOS7MTEWUi8x91YmsHNyzJVT/WApbFFx3MQGhkf+XdimVhpyo5/G0PBY91zg==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.6.tgz",
+      "integrity": "sha512-IAkDNz3TpxwISTGVdQijwyHBZrbFgLlRi5YXcvaEHtgbmayLSDcJmH5nV1MFgo/x2QdKcHBkOYHdjhKxUAcPwg==",
       "cpu": [
         "ia32"
       ],
@@ -287,9 +287,9 @@
       }
     },
     "node_modules/esbuild-linux-64": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.53.tgz",
-      "integrity": "sha512-pP/FA55j/fzAV7N9DF31meAyjOH6Bjuo3aSKPh26+RW85ZEtbJv9nhoxmGTd9FOqjx59Tc1ZbrJabuiXlMwuZQ==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.6.tgz",
+      "integrity": "sha512-gQPksyrEYfA4LJwyfTQWAZaVZCx4wpaLrSzo2+Xc9QLC+i/sMWmX31jBjrn4nLJCd79KvwCinto36QC7BEIU/A==",
       "cpu": [
         "x64"
       ],
@@ -303,9 +303,9 @@
       }
     },
     "node_modules/esbuild-linux-arm": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.53.tgz",
-      "integrity": "sha512-/u81NGAVZMopbmzd21Nu/wvnKQK3pT4CrvQ8BTje1STXcQAGnfyKgQlj3m0j2BzYbvQxSy+TMck4TNV2onvoPA==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.6.tgz",
+      "integrity": "sha512-xZ0Bq2aivsthDjA/ytQZzxrxIZbG0ATJYMJxNeOIBc1zUjpbVpzBKgllOZMsTSXMHFHGrow6TnCcgwqY0+oEoQ==",
       "cpu": [
         "arm"
       ],
@@ -319,9 +319,9 @@
       }
     },
     "node_modules/esbuild-linux-arm64": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.53.tgz",
-      "integrity": "sha512-GDmWITT+PMsjCA6/lByYk7NyFssW4Q6in32iPkpjZ/ytSyH+xeEx8q7HG3AhWH6heemEYEWpTll/eui3jwlSnw==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.6.tgz",
+      "integrity": "sha512-aovDkclFa6C9EdZVBuOXxqZx83fuoq8097xZKhEPSygwuy4Lxs8J4anHG7kojAsR+31lfUuxzOo2tHxv7EiNHA==",
       "cpu": [
         "arm64"
       ],
@@ -335,9 +335,9 @@
       }
     },
     "node_modules/esbuild-linux-mips64le": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.53.tgz",
-      "integrity": "sha512-d6/XHIQW714gSSp6tOOX2UscedVobELvQlPMkInhx1NPz4ThZI9uNLQ4qQJHGBGKGfu+rtJsxM4NVHLhnNRdWQ==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.6.tgz",
+      "integrity": "sha512-wVpW8wkWOGizsCqCwOR/G3SHwhaecpGy3fic9BF1r7vq4djLjUcA8KunDaBCjJ6TgLQFhJ98RjDuyEf8AGjAvw==",
       "cpu": [
         "mips64el"
       ],
@@ -351,9 +351,9 @@
       }
     },
     "node_modules/esbuild-linux-ppc64le": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.53.tgz",
-      "integrity": "sha512-ndnJmniKPCB52m+r6BtHHLAOXw+xBCWIxNnedbIpuREOcbSU/AlyM/2dA3BmUQhsHdb4w3amD5U2s91TJ3MzzA==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.6.tgz",
+      "integrity": "sha512-z6w6gsPH/Y77uchocluDC8tkCg9rfkcPTePzZKNr879bF4tu7j9t255wuNOCE396IYEGxY7y8u2HJ9i7kjCLVw==",
       "cpu": [
         "ppc64"
       ],
@@ -367,9 +367,9 @@
       }
     },
     "node_modules/esbuild-linux-riscv64": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.53.tgz",
-      "integrity": "sha512-yG2sVH+QSix6ct4lIzJj329iJF3MhloLE6/vKMQAAd26UVPVkhMFqFopY+9kCgYsdeWvXdPgmyOuKa48Y7+/EQ==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.6.tgz",
+      "integrity": "sha512-pfK/3MJcmbfU399TnXW5RTPS1S+ID6ra+CVj9TFZ2s0q9Ja1F5A1VirUUvViPkjiw+Kq3zveyn6U09Wg1zJXrw==",
       "cpu": [
         "riscv64"
       ],
@@ -383,9 +383,9 @@
       }
     },
     "node_modules/esbuild-linux-s390x": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.53.tgz",
-      "integrity": "sha512-OCJlgdkB+XPYndHmw6uZT7jcYgzmx9K+28PVdOa/eLjdoYkeAFvH5hTwX4AXGLZLH09tpl4bVsEtvuyUldaNCg==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.6.tgz",
+      "integrity": "sha512-OZeeDu32liefcwAE63FhVqM4heWTC8E3MglOC7SK0KYocDdY/6jyApw0UDkDHlcEK9mW6alX/SH9r3PDjcCo/Q==",
       "cpu": [
         "s390x"
       ],
@@ -399,9 +399,9 @@
       }
     },
     "node_modules/esbuild-netbsd-64": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.53.tgz",
-      "integrity": "sha512-gp2SB+Efc7MhMdWV2+pmIs/Ja/Mi5rjw+wlDmmbIn68VGXBleNgiEZG+eV2SRS0kJEUyHNedDtwRIMzaohWedQ==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.6.tgz",
+      "integrity": "sha512-kaxw61wcHMyiEsSsi5ut1YYs/hvTC2QkxJwyRvC2Cnsz3lfMLEu8zAjpBKWh9aU/N0O/gsRap4wTur5GRuSvBA==",
       "cpu": [
         "x64"
       ],
@@ -415,9 +415,9 @@
       }
     },
     "node_modules/esbuild-openbsd-64": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.53.tgz",
-      "integrity": "sha512-eKQ30ZWe+WTZmteDYg8S+YjHV5s4iTxeSGhJKJajFfQx9TLZJvsJX0/paqwP51GicOUruFpSUAs2NCc0a4ivQQ==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.6.tgz",
+      "integrity": "sha512-CuoY60alzYfIZapUHqFXqXbj88bbRJu8Fp9okCSHRX2zWIcGz4BXAHXiG7dlCye5nFVrY72psesLuWdusyf2qw==",
       "cpu": [
         "x64"
       ],
@@ -431,9 +431,9 @@
       }
     },
     "node_modules/esbuild-sunos-64": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.53.tgz",
-      "integrity": "sha512-OWLpS7a2FrIRukQqcgQqR1XKn0jSJoOdT+RlhAxUoEQM/IpytS3FXzCJM6xjUYtpO5GMY0EdZJp+ur2pYdm39g==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.6.tgz",
+      "integrity": "sha512-1ceefLdPWcd1nW/ZLruPEYxeUEAVX0YHbG7w+BB4aYgfknaLGotI/ZvPWUZpzhC8l1EybrVlz++lm3E6ODIJOg==",
       "cpu": [
         "x64"
       ],
@@ -447,9 +447,9 @@
       }
     },
     "node_modules/esbuild-windows-32": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.53.tgz",
-      "integrity": "sha512-m14XyWQP5rwGW0tbEfp95U6A0wY0DYPInWBB7D69FAXUpBpBObRoGTKRv36lf2RWOdE4YO3TNvj37zhXjVL5xg==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.6.tgz",
+      "integrity": "sha512-pBqdOsKqCD5LRYiwF29PJRDJZi7/Wgkz46u3d17MRFmrLFcAZDke3nbdDa1c8YgY78RiemudfCeAemN8EBlIpA==",
       "cpu": [
         "ia32"
       ],
@@ -463,9 +463,9 @@
       }
     },
     "node_modules/esbuild-windows-64": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.53.tgz",
-      "integrity": "sha512-s9skQFF0I7zqnQ2K8S1xdLSfZFsPLuOGmSx57h2btSEswv0N0YodYvqLcJMrNMXh6EynOmWD7rz+0rWWbFpIHQ==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.6.tgz",
+      "integrity": "sha512-KpPOh4aTOo//g9Pk2oVAzXMpc9Sz9n5A9sZTmWqDSXCiiachfFhbuFlsKBGATYCVitXfmBIJ4nNYYWSOdz4hQg==",
       "cpu": [
         "x64"
       ],
@@ -479,9 +479,9 @@
       }
     },
     "node_modules/esbuild-windows-arm64": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.53.tgz",
-      "integrity": "sha512-E+5Gvb+ZWts+00T9II6wp2L3KG2r3iGxByqd/a1RmLmYWVsSVUjkvIxZuJ3hYTIbhLkH5PRwpldGTKYqVz0nzQ==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.6.tgz",
+      "integrity": "sha512-DB3G2x9OvFEa00jV+OkDBYpufq5x/K7a6VW6E2iM896DG4ZnAvJKQksOsCPiM1DUaa+DrijXAQ/ZOcKAqf/3Hg==",
       "cpu": [
         "arm64"
       ],
@@ -558,9 +558,9 @@
       "dev": true
     },
     "node_modules/marked": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.18.tgz",
-      "integrity": "sha512-wbLDJ7Zh0sqA0Vdg6aqlbT+yPxqLblpAZh1mK2+AO2twQkPywvvqQNfEPVwSSRjZ7dZcdeVBIAgiO7MMp3Dszw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
+      "integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA==",
       "dev": true,
       "bin": {
         "marked": "bin/marked.js"
@@ -698,25 +698,25 @@
       "integrity": "sha512-VzsxlZPdsXaSfwFuUljVIr6YHjvHxWCwvURKRJq8GcP22XEnq+gGVP7ByVMJW9SL9cUH3eLPKwSsh9KH3W002w=="
     },
     "@esbuild/linux-loong64": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.53.tgz",
-      "integrity": "sha512-W2dAL6Bnyn4xa/QRSU3ilIK4EzD5wgYXKXJiS1HDF5vU3675qc2bvFyLwbUcdmssDveyndy7FbitrCoiV/eMLg==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.6.tgz",
+      "integrity": "sha512-hqmVU2mUjH6J2ZivHphJ/Pdse2ZD+uGCHK0uvsiLDk/JnSedEVj77CiVUnbMKuU4tih1TZZL8tG9DExQg/GZsw==",
       "dev": true,
       "optional": true
     },
     "@minify-html/node": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@minify-html/node/-/node-0.9.2.tgz",
-      "integrity": "sha512-qXu2s34R9UgdBaofrF1OwEQXhVNsR9gK8knpQF2zSl00XFgiUKinfk6zyQu29Cwy2X4wPtOhzbg5K+vjyZnvQw==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@minify-html/node/-/node-0.10.0.tgz",
+      "integrity": "sha512-qbTIPTrHEeFJ52bXvFxKFkY5NGir0vWrT4jri5DIo6awQJX1gK5m5ST4l2Z7SK94HrhjHhg6GZoDbS0nK2VW0w==",
       "dev": true,
       "requires": {
         "cargo-cp-artifact": "^0.1"
       }
     },
     "@popperjs/core": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
-      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
+      "version": "2.11.6",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
+      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -765,171 +765,171 @@
       "dev": true
     },
     "esbuild": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.53.tgz",
-      "integrity": "sha512-ohO33pUBQ64q6mmheX1mZ8mIXj8ivQY/L4oVuAshr+aJI+zLl+amrp3EodrUNDNYVrKJXGPfIHFGhO8slGRjuw==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.6.tgz",
+      "integrity": "sha512-sgLOv3l4xklvXzzczhRwKRotyrfyZ2i1fCS6PTOLPd9wevDPArGU8HFtHrHCOcsMwTjLjzGm15gvC8uxVzQf+w==",
       "dev": true,
       "requires": {
-        "@esbuild/linux-loong64": "0.14.53",
-        "esbuild-android-64": "0.14.53",
-        "esbuild-android-arm64": "0.14.53",
-        "esbuild-darwin-64": "0.14.53",
-        "esbuild-darwin-arm64": "0.14.53",
-        "esbuild-freebsd-64": "0.14.53",
-        "esbuild-freebsd-arm64": "0.14.53",
-        "esbuild-linux-32": "0.14.53",
-        "esbuild-linux-64": "0.14.53",
-        "esbuild-linux-arm": "0.14.53",
-        "esbuild-linux-arm64": "0.14.53",
-        "esbuild-linux-mips64le": "0.14.53",
-        "esbuild-linux-ppc64le": "0.14.53",
-        "esbuild-linux-riscv64": "0.14.53",
-        "esbuild-linux-s390x": "0.14.53",
-        "esbuild-netbsd-64": "0.14.53",
-        "esbuild-openbsd-64": "0.14.53",
-        "esbuild-sunos-64": "0.14.53",
-        "esbuild-windows-32": "0.14.53",
-        "esbuild-windows-64": "0.14.53",
-        "esbuild-windows-arm64": "0.14.53"
+        "@esbuild/linux-loong64": "0.15.6",
+        "esbuild-android-64": "0.15.6",
+        "esbuild-android-arm64": "0.15.6",
+        "esbuild-darwin-64": "0.15.6",
+        "esbuild-darwin-arm64": "0.15.6",
+        "esbuild-freebsd-64": "0.15.6",
+        "esbuild-freebsd-arm64": "0.15.6",
+        "esbuild-linux-32": "0.15.6",
+        "esbuild-linux-64": "0.15.6",
+        "esbuild-linux-arm": "0.15.6",
+        "esbuild-linux-arm64": "0.15.6",
+        "esbuild-linux-mips64le": "0.15.6",
+        "esbuild-linux-ppc64le": "0.15.6",
+        "esbuild-linux-riscv64": "0.15.6",
+        "esbuild-linux-s390x": "0.15.6",
+        "esbuild-netbsd-64": "0.15.6",
+        "esbuild-openbsd-64": "0.15.6",
+        "esbuild-sunos-64": "0.15.6",
+        "esbuild-windows-32": "0.15.6",
+        "esbuild-windows-64": "0.15.6",
+        "esbuild-windows-arm64": "0.15.6"
       }
     },
     "esbuild-android-64": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.53.tgz",
-      "integrity": "sha512-fIL93sOTnEU+NrTAVMIKiAw0YH22HWCAgg4N4Z6zov2t0kY9RAJ50zY9ZMCQ+RT6bnOfDt8gCTnt/RaSNA2yRA==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.6.tgz",
+      "integrity": "sha512-Z1CHSgB1crVQi2LKSBwSkpaGtaloVz0ZIYcRMsvHc3uSXcR/x5/bv9wcZspvH/25lIGTaViosciS/NS09ERmVA==",
       "dev": true,
       "optional": true
     },
     "esbuild-android-arm64": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.53.tgz",
-      "integrity": "sha512-PC7KaF1v0h/nWpvlU1UMN7dzB54cBH8qSsm7S9mkwFA1BXpaEOufCg8hdoEI1jep0KeO/rjZVWrsH8+q28T77A==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.6.tgz",
+      "integrity": "sha512-mvM+gqNxqKm2pCa3dnjdRzl7gIowuc4ga7P7c3yHzs58Im8v/Lfk1ixSgQ2USgIywT48QWaACRa3F4MG7djpSw==",
       "dev": true,
       "optional": true
     },
     "esbuild-darwin-64": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.53.tgz",
-      "integrity": "sha512-gE7P5wlnkX4d4PKvLBUgmhZXvL7lzGRLri17/+CmmCzfncIgq8lOBvxGMiQ4xazplhxq+72TEohyFMZLFxuWvg==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.6.tgz",
+      "integrity": "sha512-BsfVt3usScAfGlXJiGtGamwVEOTM8AiYiw1zqDWhGv6BncLXCnTg1As+90mxWewdTZKq3iIy8s9g8CKkrrAXVw==",
       "dev": true,
       "optional": true
     },
     "esbuild-darwin-arm64": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.53.tgz",
-      "integrity": "sha512-otJwDU3hnI15Q98PX4MJbknSZ/WSR1I45il7gcxcECXzfN4Mrpft5hBDHXNRnCh+5858uPXBXA1Vaz2jVWLaIA==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.6.tgz",
+      "integrity": "sha512-CnrAeJaEpPakUobhqO4wVSA4Zm6TPaI5UY4EsI62j9mTrjIyQPXA1n4Ju6Iu5TVZRnEqV6q8blodgYJ6CJuwCA==",
       "dev": true,
       "optional": true
     },
     "esbuild-freebsd-64": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.53.tgz",
-      "integrity": "sha512-WkdJa8iyrGHyKiPF4lk0MiOF87Q2SkE+i+8D4Cazq3/iqmGPJ6u49je300MFi5I2eUsQCkaOWhpCVQMTKGww2w==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.6.tgz",
+      "integrity": "sha512-+qFdmqi+jkAsxsNJkaWVrnxEUUI50nu6c3MBVarv3RCDCbz7ZS1a4ZrdkwEYFnKcVWu6UUE0Kkb1SQ1yGEG6sg==",
       "dev": true,
       "optional": true
     },
     "esbuild-freebsd-arm64": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.53.tgz",
-      "integrity": "sha512-9T7WwCuV30NAx0SyQpw8edbKvbKELnnm1FHg7gbSYaatH+c8WJW10g/OdM7JYnv7qkimw2ZTtSA+NokOLd2ydQ==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.6.tgz",
+      "integrity": "sha512-KtQkQOhnNciXm2yrTYZMD3MOm2zBiiwFSU+dkwNbcfDumzzUprr1x70ClTdGuZwieBS1BM/k0KajRQX7r504Xw==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-32": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.53.tgz",
-      "integrity": "sha512-VGanLBg5en2LfGDgLEUxQko2lqsOS7MTEWUi8x91YmsHNyzJVT/WApbFFx3MQGhkf+XdimVhpyo5/G0PBY91zg==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.6.tgz",
+      "integrity": "sha512-IAkDNz3TpxwISTGVdQijwyHBZrbFgLlRi5YXcvaEHtgbmayLSDcJmH5nV1MFgo/x2QdKcHBkOYHdjhKxUAcPwg==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-64": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.53.tgz",
-      "integrity": "sha512-pP/FA55j/fzAV7N9DF31meAyjOH6Bjuo3aSKPh26+RW85ZEtbJv9nhoxmGTd9FOqjx59Tc1ZbrJabuiXlMwuZQ==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.6.tgz",
+      "integrity": "sha512-gQPksyrEYfA4LJwyfTQWAZaVZCx4wpaLrSzo2+Xc9QLC+i/sMWmX31jBjrn4nLJCd79KvwCinto36QC7BEIU/A==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-arm": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.53.tgz",
-      "integrity": "sha512-/u81NGAVZMopbmzd21Nu/wvnKQK3pT4CrvQ8BTje1STXcQAGnfyKgQlj3m0j2BzYbvQxSy+TMck4TNV2onvoPA==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.6.tgz",
+      "integrity": "sha512-xZ0Bq2aivsthDjA/ytQZzxrxIZbG0ATJYMJxNeOIBc1zUjpbVpzBKgllOZMsTSXMHFHGrow6TnCcgwqY0+oEoQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-arm64": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.53.tgz",
-      "integrity": "sha512-GDmWITT+PMsjCA6/lByYk7NyFssW4Q6in32iPkpjZ/ytSyH+xeEx8q7HG3AhWH6heemEYEWpTll/eui3jwlSnw==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.6.tgz",
+      "integrity": "sha512-aovDkclFa6C9EdZVBuOXxqZx83fuoq8097xZKhEPSygwuy4Lxs8J4anHG7kojAsR+31lfUuxzOo2tHxv7EiNHA==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-mips64le": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.53.tgz",
-      "integrity": "sha512-d6/XHIQW714gSSp6tOOX2UscedVobELvQlPMkInhx1NPz4ThZI9uNLQ4qQJHGBGKGfu+rtJsxM4NVHLhnNRdWQ==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.6.tgz",
+      "integrity": "sha512-wVpW8wkWOGizsCqCwOR/G3SHwhaecpGy3fic9BF1r7vq4djLjUcA8KunDaBCjJ6TgLQFhJ98RjDuyEf8AGjAvw==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-ppc64le": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.53.tgz",
-      "integrity": "sha512-ndnJmniKPCB52m+r6BtHHLAOXw+xBCWIxNnedbIpuREOcbSU/AlyM/2dA3BmUQhsHdb4w3amD5U2s91TJ3MzzA==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.6.tgz",
+      "integrity": "sha512-z6w6gsPH/Y77uchocluDC8tkCg9rfkcPTePzZKNr879bF4tu7j9t255wuNOCE396IYEGxY7y8u2HJ9i7kjCLVw==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-riscv64": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.53.tgz",
-      "integrity": "sha512-yG2sVH+QSix6ct4lIzJj329iJF3MhloLE6/vKMQAAd26UVPVkhMFqFopY+9kCgYsdeWvXdPgmyOuKa48Y7+/EQ==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.6.tgz",
+      "integrity": "sha512-pfK/3MJcmbfU399TnXW5RTPS1S+ID6ra+CVj9TFZ2s0q9Ja1F5A1VirUUvViPkjiw+Kq3zveyn6U09Wg1zJXrw==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-s390x": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.53.tgz",
-      "integrity": "sha512-OCJlgdkB+XPYndHmw6uZT7jcYgzmx9K+28PVdOa/eLjdoYkeAFvH5hTwX4AXGLZLH09tpl4bVsEtvuyUldaNCg==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.6.tgz",
+      "integrity": "sha512-OZeeDu32liefcwAE63FhVqM4heWTC8E3MglOC7SK0KYocDdY/6jyApw0UDkDHlcEK9mW6alX/SH9r3PDjcCo/Q==",
       "dev": true,
       "optional": true
     },
     "esbuild-netbsd-64": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.53.tgz",
-      "integrity": "sha512-gp2SB+Efc7MhMdWV2+pmIs/Ja/Mi5rjw+wlDmmbIn68VGXBleNgiEZG+eV2SRS0kJEUyHNedDtwRIMzaohWedQ==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.6.tgz",
+      "integrity": "sha512-kaxw61wcHMyiEsSsi5ut1YYs/hvTC2QkxJwyRvC2Cnsz3lfMLEu8zAjpBKWh9aU/N0O/gsRap4wTur5GRuSvBA==",
       "dev": true,
       "optional": true
     },
     "esbuild-openbsd-64": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.53.tgz",
-      "integrity": "sha512-eKQ30ZWe+WTZmteDYg8S+YjHV5s4iTxeSGhJKJajFfQx9TLZJvsJX0/paqwP51GicOUruFpSUAs2NCc0a4ivQQ==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.6.tgz",
+      "integrity": "sha512-CuoY60alzYfIZapUHqFXqXbj88bbRJu8Fp9okCSHRX2zWIcGz4BXAHXiG7dlCye5nFVrY72psesLuWdusyf2qw==",
       "dev": true,
       "optional": true
     },
     "esbuild-sunos-64": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.53.tgz",
-      "integrity": "sha512-OWLpS7a2FrIRukQqcgQqR1XKn0jSJoOdT+RlhAxUoEQM/IpytS3FXzCJM6xjUYtpO5GMY0EdZJp+ur2pYdm39g==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.6.tgz",
+      "integrity": "sha512-1ceefLdPWcd1nW/ZLruPEYxeUEAVX0YHbG7w+BB4aYgfknaLGotI/ZvPWUZpzhC8l1EybrVlz++lm3E6ODIJOg==",
       "dev": true,
       "optional": true
     },
     "esbuild-windows-32": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.53.tgz",
-      "integrity": "sha512-m14XyWQP5rwGW0tbEfp95U6A0wY0DYPInWBB7D69FAXUpBpBObRoGTKRv36lf2RWOdE4YO3TNvj37zhXjVL5xg==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.6.tgz",
+      "integrity": "sha512-pBqdOsKqCD5LRYiwF29PJRDJZi7/Wgkz46u3d17MRFmrLFcAZDke3nbdDa1c8YgY78RiemudfCeAemN8EBlIpA==",
       "dev": true,
       "optional": true
     },
     "esbuild-windows-64": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.53.tgz",
-      "integrity": "sha512-s9skQFF0I7zqnQ2K8S1xdLSfZFsPLuOGmSx57h2btSEswv0N0YodYvqLcJMrNMXh6EynOmWD7rz+0rWWbFpIHQ==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.6.tgz",
+      "integrity": "sha512-KpPOh4aTOo//g9Pk2oVAzXMpc9Sz9n5A9sZTmWqDSXCiiachfFhbuFlsKBGATYCVitXfmBIJ4nNYYWSOdz4hQg==",
       "dev": true,
       "optional": true
     },
     "esbuild-windows-arm64": {
-      "version": "0.14.53",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.53.tgz",
-      "integrity": "sha512-E+5Gvb+ZWts+00T9II6wp2L3KG2r3iGxByqd/a1RmLmYWVsSVUjkvIxZuJ3hYTIbhLkH5PRwpldGTKYqVz0nzQ==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.6.tgz",
+      "integrity": "sha512-DB3G2x9OvFEa00jV+OkDBYpufq5x/K7a6VW6E2iM896DG4ZnAvJKQksOsCPiM1DUaa+DrijXAQ/ZOcKAqf/3Hg==",
       "dev": true,
       "optional": true
     },
@@ -982,9 +982,9 @@
       "dev": true
     },
     "marked": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.18.tgz",
-      "integrity": "sha512-wbLDJ7Zh0sqA0Vdg6aqlbT+yPxqLblpAZh1mK2+AO2twQkPywvvqQNfEPVwSSRjZ7dZcdeVBIAgiO7MMp3Dszw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
+      "integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA==",
       "dev": true
     },
     "minimatch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -618,9 +618,9 @@
       "dev": true
     },
     "node_modules/postcss": {
-      "version": "8.4.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
-      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+      "version": "8.4.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
+      "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
       "dev": true,
       "funding": [
         {
@@ -1024,9 +1024,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.4.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
-      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+      "version": "8.4.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
+      "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
       "dev": true,
       "requires": {
         "nanoid": "^3.3.4",

--- a/package.json
+++ b/package.json
@@ -20,15 +20,15 @@
   "repository": "github:artichoke/www.artichokeruby.org",
   "dependencies": {
     "@artichokeruby/logo": "^0.12.0",
-    "@popperjs/core": "^2.11.5",
+    "@popperjs/core": "^2.11.6",
     "bootstrap": "^5.2.0"
   },
   "devDependencies": {
-    "@minify-html/node": "^0.9.2",
-    "esbuild": "^0.14.53",
+    "@minify-html/node": "^0.10.0",
+    "esbuild": "^0.15.6",
     "eta": "^1.12.3",
     "highlight.js": "^11.6.0",
-    "marked": "^4.0.18",
+    "marked": "^4.1.0",
     "purgecss": "^4.1.3"
   },
   "eslintConfig": {


### PR DESCRIPTION
```
Upgrading /Users/lopopolo/dev/artichoke/[www.artichokeruby.org/package.json](http://www.artichokeruby.org/package.json)
[====================] 9/9 100%

 @popperjs/core      ^2.11.5  →  ^2.11.6
 @minify-html/node    ^0.9.2  →  ^0.10.0
 esbuild            ^0.14.53  →  ^0.15.6
 marked              ^4.0.18  →   ^4.1.0

Run npm install to install new versions.
```

Rollup of:

- #517 
- #518 
- #519 
- #520 


`@minify-html/node@^0.10.x` drops support for macOS arm64.