### PR TITLE
Upgrade eta to ^2.0.0 to address CVE-2023-23630

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -28,7 +28,7 @@
   description: "Area: Security vulnerabilities and unsoundness issues."
 - name: "A-webapp"
   color: "f7e101"
-  description: "Area: Web frontend for the playground."
+  description: "Area: Web frontend for the project website."
 - name: "A-webpack"
   color: "f7e101"
   description: "Area: Webpack configuration."

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "devDependencies": {
         "@minify-html/node": "^0.10.3",
         "esbuild": "^0.16.12",
-        "eta": "^1.12.3",
+        "eta": "^2.0.0",
         "highlight.js": "^11.7.0",
         "marked": "^4.2.5"
       }
@@ -468,9 +468,9 @@
       }
     },
     "node_modules/eta": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/eta/-/eta-1.12.3.tgz",
-      "integrity": "sha512-qHixwbDLtekO/d51Yr4glcaUJCIjGVJyTzuqV4GPlgZo1YpgOKG+avQynErZIYrfM6JIJdtiG2Kox8tbb+DoGg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-2.0.0.tgz",
+      "integrity": "sha512-NqE7S2VmVwgMS8yBxsH4VgNQjNjLq1gfGU0u9I6Cjh468nPRMoDfGdK9n1p/3Dvsw3ebklDkZsFAnKJ9sefjBA==",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@minify-html/node": "^0.10.3",
     "esbuild": "^0.16.12",
-    "eta": "^1.12.3",
+    "eta": "^2.0.0",
     "highlight.js": "^11.7.0",
     "marked": "^4.2.5"
   },


### PR DESCRIPTION
All eta versions less than 2.0.0 are vulnerable to an XSS attack when used in conjunction with express. The Artichoke website does not use eta in this way.

- CVE-2023-23630
- https://github.com/advisories/GHSA-xrh7-m5pp-39r6

Remediation steps:

```
npm i -D eta@^2.0.0
```