### PR TITLE
Ubuntu Docker images use a 22.04 base now

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -44,7 +44,7 @@
     "docker": {
       "go": "Docker",
       "title": "Docker images",
-      "content": "Nightly builds of Artichoke are pushed to Docker Hub. Images are built on Ubuntu 20.04, Debian Bullseye Slim, and Alpine 3.",
+      "content": "Nightly builds of Artichoke are pushed to Docker Hub. Images are built on Ubuntu 22.04, Debian Bullseye Slim, and Alpine 3.",
       "hint": "These daily images track the latest trunk commit of Artichoke.",
       "button": "Docker Hub"
     },

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -43,7 +43,7 @@
     "docker": {
       "go": "Docker",
       "title": "Docker镜像",
-      "content": "Artichoke的nightly构建会被推送至Docker Hub。镜像的构建基于Ubuntu 20.04、Debian Bullseye Slim和Alpine 3。",
+      "content": "Artichoke的nightly构建会被推送至Docker Hub。镜像的构建基于Ubuntu 22.04、Debian Bullseye Slim和Alpine 3。",
       "hint": "这些每日镜像包含了Artichoke的最新trunk commit。",
       "button": "Docker Hub"
     },


### PR DESCRIPTION
See:

- https://github.com/artichoke/docker-artichoke-nightly/pull/146