### PR TITLE
Improve local build process

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,8 @@ updates:
       - lopopolo
     labels:
       - A-deps
+    ignore:
+      - dependency-name: "marked"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "rimraf"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
         run: npm ci
 
       - name: Build Webapp
-        run: node build.mjs --release
+        run: node build.mjs
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.2

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Artichoke Ruby.
 To launch a local development server:
 
 ```sh
-npm run dev:debug # or npm run dev:release
+npm run dev
 ```
 
 ## Deployment

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@artichokeruby/logo": "^0.12.0",
         "@popperjs/core": "^2.11.8",
-        "bootstrap": "^5.3.1"
+        "bootstrap": "^5.3.1",
+        "marked": "^4.3.0"
       },
       "devDependencies": {
         "@minify-html/node": "^0.11.1",
@@ -19,9 +20,8 @@
         "eslint": "8.56.0",
         "eta": "^2.2.0",
         "highlight.js": "^11.8.0",
-        "marked": "^5.1.2",
-        "marked-highlight": "^2.0.4",
-        "prettier": "^3.2.4"
+        "prettier": "^3.2.4",
+        "rimraf": "^3.0.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1268,24 +1268,14 @@
       "dev": true
     },
     "node_modules/marked": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-5.1.2.tgz",
-      "integrity": "sha512-ahRPGXJpjMjwSOlBoTMZAK7ATXkli5qCPxZ21TG44rx1KEo44bii4ekgTDQPNRQ4Kh7JMb9Ub1PVk1NxRSsorg==",
-      "dev": true,
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 16"
-      }
-    },
-    "node_modules/marked-highlight": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/marked-highlight/-/marked-highlight-2.0.4.tgz",
-      "integrity": "sha512-hnm+rY3p+DQlSd2uY3zSXec+1kq5x9lD3+PWOMz0ROcil4Btcbt///Fto52jqWWt7XBGiTRk+1+w2rGfx2U2Sw==",
-      "dev": true,
-      "peerDependencies": {
-        "marked": "^4 || ^5 || ^6 || ^7"
+        "node": ">= 12"
       }
     },
     "node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "@artichokeruby/logo": "^0.12.0",
     "@popperjs/core": "^2.11.8",
-    "bootstrap": "^5.3.1"
+    "bootstrap": "^5.3.1",
+    "marked": "^4.3.0"
   },
   "devDependencies": {
     "@minify-html/node": "^0.11.1",
@@ -29,9 +30,8 @@
     "eslint": "8.56.0",
     "eta": "^2.2.0",
     "highlight.js": "^11.8.0",
-    "marked": "^5.1.2",
-    "marked-highlight": "^2.0.4",
-    "prettier": "^3.2.4"
+    "prettier": "^3.2.4",
+    "rimraf": "^3.0.2"
   },
   "eslintConfig": {
     "env": {
@@ -46,17 +46,14 @@
     }
   },
   "scripts": {
-    "build:debug": "node build.mjs",
-    "build:release": "node build.mjs --release",
-    "clean": "rm -rf dist",
-    "dev:debug": "npx concurrently \"npm:serve\" \"npm:watch:debug\"",
-    "dev:release": "npx concurrently \"npm:serve\" \"npm:watch:release\"",
-    "fmt": "prettier --write \"**/*\"",
-    "lint": "npx eslint . --ext .js,.jsx,.mjs,.ts,.tsx",
-    "lint:fix": "npx eslint . --ext .js,.jsx,.mjs,.ts,.tsx --fix",
-    "release:markdown_link_check": "find . -name '*.md' -and -not -path '*/node_modules/*' | sort | xargs -n1 npx markdown-link-check --config .github/markdown-link-check.json",
+    "dev": "npx concurrently \"npm:serve\" \"npm:watch\"",
+    "build": "node build.mjs",
     "serve": "python3 -u -m http.server --directory dist --bind localhost 0",
-    "watch:debug": "npx chokidar-cli \"package.json\" \"package-lock.json\" \"build.mjs\" \"src/**/*\" -c \"npm run build:debug\" --initial",
-    "watch:release": "npx chokidar-cli \"package.json\" \"package-lock.json\" \"build.mjs\" \"src/**/*\" -c \"npm run build:release\" --initial"
+    "watch": "npx chokidar-cli \"package.json\" \"package-lock.json\" \"build.mjs\" \"src/**/*\" -c \"npm run build\" --initial",
+    "clean": "rimraf dist",
+    "fmt": "prettier --write \"**/*\"",
+    "lint": "eslint . --ext .js,.jsx,.mjs,.ts,.tsx",
+    "lint:fix": "eslint . --ext .js,.jsx,.mjs,.ts,.tsx --fix",
+    "release:markdown_link_check": "find . -name '*.md' -and -not -path '*/node_modules/*' | sort | xargs -n1 npx markdown-link-check --config .github/markdown-link-check.json"
   }
 }


### PR DESCRIPTION
- Downgrade `marked` to v4
- Install `rimraf` v3 and use it for the `clean` run script
- Suppress dependabot updates for `marked` and `rimraf`
- Remove `--release` flag from `build.mjs`
- Remove all debug/release sub tasks from package.json run scripts
- Update dev server docs in README
- Don't invoke `eslint` with `npx` in run scripts now that it is a dev dependency