### PR TITLE
Fix broken link in footer

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -224,7 +224,14 @@
       </div>
     </div>
 
-    <%~ include("/partials/footer.html", { t: it.t.footer }) %>
+    <!-- prettier-ignore -->
+    <%~ include("/partials/footer.html", {
+          page: "home",
+          t: it.t.footer,
+          locale: it.locale,
+          locales: it.locales,
+        })
+    %>
     <script async src="https://platform.twitter.com/widgets.js"></script>
     <script async type="module" src="/main.bundle.js"></script>
   </body>

--- a/src/install.html
+++ b/src/install.html
@@ -267,7 +267,14 @@
       </div>
     </div>
 
-    <%~ include("/partials/footer.html", { t: it.t.footer }) %>
+    <!-- prettier-ignore -->
+    <%~ include("/partials/footer.html", {
+          page: "install",
+          t: it.t.footer,
+          locale: it.locale,
+          locales: it.locales,
+        })
+    %>
     <script async type="module" src="/main.bundle.js"></script>
   </body>
 </html>

--- a/src/partials/footer.html
+++ b/src/partials/footer.html
@@ -76,7 +76,7 @@
     </div>
     <hr class="my-0" />
     <div class="col-12 px-0">
-      <a href="<%= it.prefix + '/' %>" aria-label="Artichoke Ruby">
+      <a href="<%= it.locale.links.home %>" aria-label="Artichoke Ruby">
         <img
           alt="Artichoke Ruby."
           title="Artichoke Ruby"


### PR DESCRIPTION
The footer wordmark link was referring to a property on 'it' that does not exist, which was rendering the link as /undefined.

This has probably been broken since the zh-Hans locale was introduced.